### PR TITLE
Rappels SMS : fréquence compatible plan gratuit Vercel

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -60,8 +60,10 @@ base des RDV enregistrés, et l'adresse se saisit manuellement.
 ## Rappels SMS (cron)
 
 `GET /api/cron/reminders` (header `Authorization: Bearer $CRON_SECRET`) envoie les
-rappels 24 h et 1 h. Sur Vercel, `vercel.json` le programme toutes les 10 minutes ;
-ailleurs, utilisez n'importe quel cron :
+rappels 24 h et 1 h. Sur Vercel plan Hobby, `vercel.json` le programme une fois par
+jour à 6h UTC (limite du plan gratuit) : le rappel « 24 h » devient un rappel le
+matin du RDV. Pour des rappels précis (dont le 1 h avant), appelez la route toutes
+les 10 minutes depuis un cron externe gratuit type cron-job.org :
 
 ```
 */10 * * * * curl -s -H "Authorization: Bearer $CRON_SECRET" https://votre-domaine/api/cron/reminders

--- a/app/vercel.json
+++ b/app/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/reminders",
-      "schedule": "*/10 * * * *"
+      "schedule": "0 6 * * *"
     }
   ]
 }


### PR DESCRIPTION
Le plan gratuit (Hobby) de Vercel limite les tâches planifiées à une exécution par jour — le déploiement était bloqué par notre fréquence de 10 minutes. Cette correction passe le rappel automatique à une fois par jour (6h UTC, soit le matin du rendez-vous) et documente l'option d'un cron externe gratuit pour retrouver les rappels précis 24 h / 1 h avant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_