### PR TITLE
Comptes particuliers et connexion unifiée

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -117,6 +117,17 @@ model Pro {
   updatedAt      DateTime @updatedAt
 }
 
+// Comptes particuliers (clients). La réservation reste possible sans compte ;
+// le compte permet de retrouver et gérer ses rendez-vous (rattachés par email).
+model Client {
+  id           String   @id @default(cuid())
+  createdAt    DateTime @default(now())
+  name         String
+  email        String   @unique
+  passwordHash String
+  phone        String   @default("")
+}
+
 // Prospects hors zone d'intervention (formulaire de contact)
 model Lead {
   id         String   @id @default(cuid())

--- a/app/src/app/api/client/login/route.ts
+++ b/app/src/app/api/client/login/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  verifyPassword,
+  createClientToken,
+  CLIENT_COOKIE_NAME,
+  CLIENT_SESSION_MAX_AGE,
+} from "@/lib/clientAuth";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/client/login — connexion d'un particulier.
+export async function POST(req: NextRequest) {
+  let body: { email?: string; password?: string } = {};
+  try {
+    body = await req.json();
+  } catch {}
+  const email = String(body.email ?? "").trim().toLowerCase();
+  const password = String(body.password ?? "");
+  const client = await prisma.client.findUnique({ where: { email } });
+  if (!client || !verifyPassword(password, client.passwordHash)) {
+    return NextResponse.json({ error: "Identifiants incorrects" }, { status: 401 });
+  }
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(CLIENT_COOKIE_NAME, createClientToken(client.id), {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: CLIENT_SESSION_MAX_AGE,
+    path: "/",
+  });
+  return res;
+}

--- a/app/src/app/api/client/logout/route.ts
+++ b/app/src/app/api/client/logout/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+import { CLIENT_COOKIE_NAME } from "@/lib/clientAuth";
+
+export const dynamic = "force-dynamic";
+
+export async function POST() {
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(CLIENT_COOKIE_NAME, "", { maxAge: 0, path: "/" });
+  return res;
+}

--- a/app/src/app/api/client/me/route.ts
+++ b/app/src/app/api/client/me/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { currentClientId } from "@/lib/clientAuth";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/client/me — profil + rendez-vous du particulier connecté
+// (rattachés par email, y compris les réservations faites sans compte).
+export async function GET() {
+  const id = currentClientId();
+  if (!id) return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  const client = await prisma.client.findUnique({ where: { id } });
+  if (!client) return NextResponse.json({ error: "introuvable" }, { status: 404 });
+
+  const bookings = await prisma.booking.findMany({
+    where: { email: client.email },
+    orderBy: { startAt: "desc" },
+    select: {
+      id: true,
+      kind: true,
+      projectType: true,
+      startAt: true,
+      address: true,
+      postalCode: true,
+      city: true,
+      status: true,
+      cancelToken: true,
+    },
+  });
+
+  return NextResponse.json({
+    client: { name: client.name, email: client.email, phone: client.phone },
+    bookings,
+  });
+}

--- a/app/src/app/api/client/register/route.ts
+++ b/app/src/app/api/client/register/route.ts
@@ -1,0 +1,46 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  hashPassword,
+  createClientToken,
+  CLIENT_COOKIE_NAME,
+  CLIENT_SESSION_MAX_AGE,
+} from "@/lib/clientAuth";
+
+export const dynamic = "force-dynamic";
+
+// POST /api/client/register — création de compte particulier.
+export async function POST(req: NextRequest) {
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+  const name = String(body.name ?? "").trim();
+  const email = String(body.email ?? "").trim().toLowerCase();
+  const password = String(body.password ?? "");
+  const phone = String(body.phone ?? "").trim();
+
+  if (!name || !/.+@.+\..+/.test(email) || password.length < 6) {
+    return NextResponse.json(
+      { error: "Nom, email valide et mot de passe (6 caractères min) requis" },
+      { status: 400 }
+    );
+  }
+  if (await prisma.client.findUnique({ where: { email } })) {
+    return NextResponse.json({ error: "email_existe" }, { status: 409 });
+  }
+  const client = await prisma.client.create({
+    data: { name, email, phone, passwordHash: hashPassword(password) },
+  });
+  const res = NextResponse.json({ ok: true });
+  res.cookies.set(CLIENT_COOKIE_NAME, createClientToken(client.id), {
+    httpOnly: true,
+    sameSite: "lax",
+    secure: process.env.NODE_ENV === "production",
+    maxAge: CLIENT_SESSION_MAX_AGE,
+    path: "/",
+  });
+  return res;
+}

--- a/app/src/app/compte/login/page.tsx
+++ b/app/src/app/compte/login/page.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+// Connexion / création de compte particulier.
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+
+export default function ClientLoginPage() {
+  const router = useRouter();
+  const [mode, setMode] = useState<"login" | "register">("login");
+  const [name, setName] = useState("");
+  const [email, setEmail] = useState("");
+  const [phone, setPhone] = useState("");
+  const [password, setPassword] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setBusy(true);
+    setError("");
+    try {
+      const url = mode === "register" ? "/api/client/register" : "/api/client/login";
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ name, email, phone, password }),
+      });
+      const data = await res.json();
+      if (res.ok) {
+        router.push("/compte");
+        router.refresh();
+      } else if (data.error === "email_existe") {
+        setError("Un compte existe déjà avec cet email. Connectez-vous.");
+        setMode("login");
+      } else {
+        setError(data.error || "Une erreur est survenue.");
+      }
+    } catch {
+      setError("Erreur réseau, réessayez.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center px-4">
+      <p className="mb-1 text-center text-3xl" aria-hidden>🌿</p>
+      <h1 className="mb-1 mt-2 text-center text-2xl font-extrabold">Mon compte</h1>
+      <p className="mb-5 text-center text-sm text-leaf-800/70">
+        Retrouvez et gérez vos rendez-vous.
+      </p>
+
+      <div className="mb-4 grid grid-cols-2 gap-2 rounded-xl bg-leaf-50 p-1">
+        <button
+          onClick={() => setMode("login")}
+          className={`rounded-lg px-3 py-2 text-sm font-semibold ${
+            mode === "login" ? "bg-white text-leaf-800 shadow-sm" : "text-leaf-800/60"
+          }`}
+        >
+          Connexion
+        </button>
+        <button
+          onClick={() => setMode("register")}
+          className={`rounded-lg px-3 py-2 text-sm font-semibold ${
+            mode === "register" ? "bg-white text-leaf-800 shadow-sm" : "text-leaf-800/60"
+          }`}
+        >
+          Créer un compte
+        </button>
+      </div>
+
+      <form onSubmit={submit} className="card space-y-4">
+        {mode === "register" && (
+          <>
+            <div>
+              <label className="label" htmlFor="name">Prénom / nom</label>
+              <input id="name" className="input" value={name} onChange={(e) => setName(e.target.value)} required />
+            </div>
+            <div>
+              <label className="label" htmlFor="phone">Téléphone</label>
+              <input id="phone" className="input" type="tel" value={phone} onChange={(e) => setPhone(e.target.value)} />
+            </div>
+          </>
+        )}
+        <div>
+          <label className="label" htmlFor="email">Email</label>
+          <input
+            id="email"
+            className="input"
+            type="email"
+            autoComplete="username"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+          {mode === "register" && (
+            <p className="mt-1 text-xs text-leaf-800/60">
+              Utilisez l&apos;email de vos réservations pour les retrouver automatiquement.
+            </p>
+          )}
+        </div>
+        <div>
+          <label className="label" htmlFor="password">Mot de passe</label>
+          <input
+            id="password"
+            className="input"
+            type="password"
+            autoComplete={mode === "register" ? "new-password" : "current-password"}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        {error && <p className="text-sm text-red-600">{error}</p>}
+        <button className="btn-primary w-full" disabled={busy}>
+          {busy ? "…" : mode === "register" ? "Créer mon compte" : "Se connecter"}
+        </button>
+      </form>
+
+      <a href="/" className="mt-6 text-center text-sm text-leaf-700 underline">← Retour à l&apos;accueil</a>
+    </main>
+  );
+}

--- a/app/src/app/compte/page.tsx
+++ b/app/src/app/compte/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+// Espace particulier : liste des rendez-vous (à venir / passés), gestion.
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type Booking = {
+  id: string;
+  kind: string;
+  projectType: string;
+  startAt: string;
+  address: string;
+  postalCode: string;
+  city: string;
+  status: string;
+  cancelToken: string;
+};
+type Client = { name: string; email: string; phone: string };
+
+const PROJECT_LABELS: Record<string, string> = {
+  entretien: "Entretien de jardin général",
+  taille_haie: "Taille de haie",
+  debroussaillage: "Débroussaillage",
+  contrat_annuel: "Contrat d'entretien à l'année",
+  autre: "Autre projet",
+};
+const STATUS_LABELS: Record<string, string> = {
+  a_faire: "À venir",
+  devis_envoye: "Devis envoyé",
+  gagne: "Confirmé",
+  perdu: "Clôturé",
+  annule: "Annulé",
+};
+
+function fmt(iso: string): string {
+  return new Date(iso).toLocaleString("fr-FR", {
+    timeZone: "Europe/Paris",
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function ClientAccount() {
+  const [client, setClient] = useState<Client | null>(null);
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("/api/client/me")
+      .then((r) => {
+        if (r.status === 401) {
+          window.location.href = "/compte/login";
+          throw new Error("unauthorized");
+        }
+        return r.json();
+      })
+      .then((data) => {
+        setClient(data.client);
+        setBookings(data.bookings ?? []);
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  async function logout() {
+    await fetch("/api/client/logout", { method: "POST" });
+    window.location.href = "/";
+  }
+
+  const now = Date.now();
+  const upcoming = bookings.filter((b) => new Date(b.startAt).getTime() >= now && b.status !== "annule");
+  const past = bookings.filter((b) => new Date(b.startAt).getTime() < now || b.status === "annule");
+
+  function card(b: Booking) {
+    return (
+      <div key={b.id} className="card">
+        <div className="flex items-start justify-between gap-2">
+          <p className="font-semibold capitalize">{fmt(b.startAt)}</p>
+          <span className="rounded-full bg-leaf-100 px-2.5 py-0.5 text-[11px] font-semibold text-leaf-800">
+            {b.kind === "chantier" ? "Chantier" : "Devis"}
+          </span>
+        </div>
+        <p className="mt-1 text-sm text-leaf-800/70">
+          {PROJECT_LABELS[b.projectType] ?? b.projectType} · {b.city || b.postalCode}
+        </p>
+        <p className="mt-1 text-sm text-leaf-800/60">{STATUS_LABELS[b.status] ?? b.status}</p>
+        {b.status !== "annule" && new Date(b.startAt).getTime() >= now && (
+          <Link href={`/annuler/${b.cancelToken}`} className="mt-2 inline-block text-sm font-semibold text-leaf-700 underline">
+            Modifier ou annuler
+          </Link>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <main className="mx-auto max-w-lg px-4 py-6 sm:max-w-2xl">
+      <div className="mb-5 flex items-center justify-between border-b border-leaf-100 pb-4">
+        <div>
+          <p className="text-xs uppercase tracking-wide text-leaf-800/50">Mon compte</p>
+          <h1 className="text-lg font-bold">{client?.name ?? ""}</h1>
+        </div>
+        <button onClick={logout} className="text-sm text-leaf-800/60 hover:text-leaf-800">
+          Déconnexion
+        </button>
+      </div>
+
+      {loading && <p className="py-8 text-center text-leaf-800/60">Chargement…</p>}
+
+      {!loading && (
+        <>
+          <div className="mb-6 flex flex-col gap-2 sm:flex-row">
+            <Link href="/#reserver" className="btn-primary">Réserver un rendez-vous</Link>
+          </div>
+
+          <h2 className="mb-3 text-lg font-bold">À venir ({upcoming.length})</h2>
+          {upcoming.length === 0 ? (
+            <p className="card py-6 text-center text-sm text-leaf-800/60">
+              Aucun rendez-vous à venir.
+            </p>
+          ) : (
+            <div className="space-y-3">{upcoming.map(card)}</div>
+          )}
+
+          {past.length > 0 && (
+            <>
+              <h2 className="mb-3 mt-8 text-lg font-bold">Historique</h2>
+              <div className="space-y-3">{past.map(card)}</div>
+            </>
+          )}
+        </>
+      )}
+    </main>
+  );
+}

--- a/app/src/app/connexion/page.tsx
+++ b/app/src/app/connexion/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link";
+import SiteHeader from "@/components/SiteHeader";
+
+export const dynamic = "force-dynamic";
+
+export const metadata = { title: "Connexion — Arboris Paysage" };
+
+// Point d'entrée unifié : le visiteur choisit son type de compte.
+export default function ConnexionPage() {
+  return (
+    <main className="mx-auto flex min-h-screen max-w-sm flex-col justify-center px-4">
+      <SiteHeader />
+      <h1 className="mb-1 mt-2 text-center text-2xl font-extrabold">Se connecter</h1>
+      <p className="mb-6 text-center text-sm text-leaf-800/70">
+        Créez votre compte ou connectez-vous.
+      </p>
+
+      <div className="space-y-3">
+        <Link href="/compte/login" className="card block transition hover:border-leaf-300">
+          <p className="font-bold text-leaf-900">Je suis un particulier</p>
+          <p className="mt-1 text-sm text-leaf-800/70">
+            Suivez et gérez vos rendez-vous de devis et d&apos;entretien.
+          </p>
+        </Link>
+        <Link href="/pro/login" className="card block transition hover:border-leaf-300">
+          <p className="font-bold text-leaf-900">Je suis un professionnel</p>
+          <p className="mt-1 text-sm text-leaf-800/70">
+            Déclarez vos disponibilités pour les devis et les chantiers.
+          </p>
+        </Link>
+      </div>
+
+      <Link href="/" className="mt-6 text-center text-sm text-leaf-700 underline">
+        ← Retour à l&apos;accueil
+      </Link>
+    </main>
+  );
+}

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -39,6 +39,11 @@ export default async function LandingPage() {
   const galleryPhotos = dbPhotos.length > 0 ? dbPhotos.map((p) => p.dataUrl) : getGalleryPhotos();
   return (
     <main className="mx-auto max-w-lg px-4 pb-16 sm:max-w-2xl">
+      <div className="flex items-center justify-end pt-3">
+        <a href="/connexion" className="text-sm font-semibold text-leaf-700">
+          Se connecter
+        </a>
+      </div>
       <SiteHeader />
 
       {/* Hero */}
@@ -138,7 +143,7 @@ export default async function LandingPage() {
         <br />
         <a href="/mentions-legales" className="underline">Mentions légales & confidentialité</a>
         {" · "}
-        <a href="/pro" className="underline">Espace professionnel</a>
+        <a href="/connexion" className="underline">Se connecter</a>
         {" · "}
         <a href="/admin" className="underline">Espace gérant</a>
       </footer>

--- a/app/src/lib/clientAuth.ts
+++ b/app/src/lib/clientAuth.ts
@@ -1,0 +1,41 @@
+// Session des comptes particuliers (clients), séparée des espaces pro et admin.
+// Le hachage de mot de passe est partagé avec proAuth.
+import { createHmac, timingSafeEqual } from "crypto";
+import { cookies } from "next/headers";
+
+export { hashPassword, verifyPassword } from "./proAuth";
+
+const CLIENT_COOKIE = "client_session";
+const SESSION_DAYS = 90;
+
+function secret(): string {
+  return process.env.AUTH_SECRET || "dev-secret-a-changer";
+}
+
+function sign(payload: string): string {
+  return createHmac("sha256", secret()).update(payload).digest("hex");
+}
+
+export function createClientToken(clientId: string): string {
+  const expires = Date.now() + SESSION_DAYS * 24 * 3600_000;
+  const payload = Buffer.from(JSON.stringify({ clientId, expires })).toString("base64url");
+  return `${payload}.${sign(payload)}`;
+}
+
+export function currentClientId(): string | null {
+  const token = cookies().get(CLIENT_COOKIE)?.value;
+  if (!token) return null;
+  const [payload, sig] = token.split(".");
+  if (!payload || !sig) return null;
+  const expected = sign(payload);
+  if (sig.length !== expected.length) return null;
+  if (!timingSafeEqual(Buffer.from(sig), Buffer.from(expected))) return null;
+  try {
+    const data = JSON.parse(Buffer.from(payload, "base64url").toString());
+    if (typeof data.expires === "number" && data.expires > Date.now()) return data.clientId;
+  } catch {}
+  return null;
+}
+
+export const CLIENT_COOKIE_NAME = CLIENT_COOKIE;
+export const CLIENT_SESSION_MAX_AGE = SESSION_DAYS * 24 * 3600;

--- a/app/src/middleware.ts
+++ b/app/src/middleware.ts
@@ -21,9 +21,17 @@ export function middleware(req: NextRequest) {
       return NextResponse.redirect(url);
     }
   }
+  if (pathname === "/compte" || (pathname.startsWith("/compte/") && pathname !== "/compte/login")) {
+    const cookie = req.cookies.get("client_session")?.value;
+    if (!cookie || !cookie.includes(".")) {
+      const url = req.nextUrl.clone();
+      url.pathname = "/compte/login";
+      return NextResponse.redirect(url);
+    }
+  }
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/admin/:path*", "/pro/:path*"],
+  matcher: ["/admin/:path*", "/pro/:path*", "/compte/:path*"],
 };


### PR DESCRIPTION
Ajoute les comptes particuliers, à côté de l'espace professionnel existant.

- Page **/connexion** : le visiteur choisit « Particulier » ou « Professionnel ».
- **Comptes particuliers** (`/compte`) : création de compte libre, puis suivi de ses rendez-vous (à venir + historique), avec liens modifier/annuler. Les rendez-vous sont retrouvés par email — y compris ceux réservés sans compte.
- La **réservation reste possible sans compte** (parcours 60 s préservé pour les pubs Meta).
- Lien « Se connecter » en tête et pied de la page d'accueil.
- Session client séparée (pro / gérant / client indépendants) ; nouvelle table `Client` créée automatiquement au déploiement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_