### PR TITLE
Créneaux devis validables par les professionnels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,21 @@ Docs : `app/ARCHITECTURE.md`.
 - RGPD : bannière de consentement obligatoire avant activation du pixel Meta
   (composant MetaPixel), notice confidentialité à l'étape 2 du tunnel.
 
+## Espaces & comptes
+
+- **Réservation client** : sans compte (parcours 60 s), 2 types de RDV (devis
+  fin de journée 16h30-20h ; chantier en journée dès 8h, durée 2h par défaut).
+- **Comptes particuliers** (`/compte`, inscription libre) : retrouvent leurs RDV
+  par email (même ceux réservés sans compte), modifier/annuler.
+- **Espace professionnel** (`/pro`, inscription libre) : statut de dispo (🟢 devis
+  / 🔵 chantier / 🟠 sous confirmation / 🔴 indispo), dates, nb de jours, rayon.
+  Vue gérant : onglet « Professionnels » dans `/admin`.
+- **Connexion unifiée** : `/connexion` (choix particulier / professionnel).
+- 3 sessions indépendantes (cookies séparés) : admin, pro, client. Mots de passe
+  hachés (scrypt), sessions signées HMAC (AUTH_SECRET).
+- **Déploiement** : Vercel plan Hobby (cron rappels 1×/jour à 6h UTC). Fusion des
+  PR vers `main` via l'outil GitHub (le client n'a pas à le faire) → redeploy auto.
+
 ## Démo interactive (artifact)
 
 Réplique cliquable du produit, publiée sur claude.ai :

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -113,6 +113,8 @@ model Pro {
   availableDays  Int      @default(0)
   // Dates disponibles : ["2026-08-12","2026-08-13",...]
   datesJson      String   @default("[]")
+  // Créneaux devis validés (fin de journée, pas de 30 min) : ["18:00","18:30",...]
+  devisSlotsJson String   @default("[]")
   note           String   @default("")
   updatedAt      DateTime @updatedAt
 }

--- a/app/src/app/admin/pros/page.tsx
+++ b/app/src/app/admin/pros/page.tsx
@@ -16,9 +16,20 @@ type Pro = {
   status: string;
   availableDays: number;
   datesJson: string;
+  devisSlotsJson: string;
   note: string;
   updatedAt: string;
 };
+
+function fmtSlots(json: string): string {
+  try {
+    const slots: string[] = JSON.parse(json);
+    if (!slots.length) return "—";
+    return slots.map((s) => s.replace(":", "h")).join(" · ");
+  } catch {
+    return "—";
+  }
+}
 
 function fmtDates(json: string): string {
   try {
@@ -95,6 +106,7 @@ export default function AdminProsPage() {
                 </p>
                 <p>🗓️ {p.availableDays} journée(s) annoncée(s)</p>
                 <p>📅 {fmtDates(p.datesJson)}</p>
+                <p>⏰ Créneaux devis : {fmtSlots(p.devisSlotsJson)}</p>
                 {p.note && <p className="rounded-xl bg-sand-50 p-3 text-leaf-800/80">{p.note}</p>}
               </div>
             </div>

--- a/app/src/app/api/pro/me/route.ts
+++ b/app/src/app/api/pro/me/route.ts
@@ -47,6 +47,12 @@ export async function PUT(req: NextRequest) {
       .slice(0, 366);
     data.datesJson = JSON.stringify(dates);
   }
+  if (Array.isArray(body.devisSlots)) {
+    const slots = (body.devisSlots as unknown[])
+      .filter((s) => typeof s === "string" && /^\d{2}:\d{2}$/.test(s))
+      .slice(0, 48);
+    data.devisSlotsJson = JSON.stringify(slots);
+  }
 
   const pro = await prisma.pro.update({ where: { id }, data });
   return NextResponse.json({ pro: sanitize(pro) });

--- a/app/src/app/pro/page.tsx
+++ b/app/src/app/pro/page.tsx
@@ -14,8 +14,12 @@ type Pro = {
   status: string;
   availableDays: number;
   datesJson: string;
+  devisSlotsJson: string;
   note: string;
 };
+
+// Créneaux devis proposés aux clients : fin de journée, toutes les 30 min.
+const DEVIS_SLOTS = ["16:30", "17:00", "17:30", "18:00", "18:30", "19:00", "19:30"];
 
 function addMonths(d: Date, n: number) {
   return new Date(d.getFullYear(), d.getMonth() + n, 1);
@@ -27,6 +31,7 @@ function ymd(d: Date) {
 export default function ProDashboard() {
   const [pro, setPro] = useState<Pro | null>(null);
   const [dates, setDates] = useState<string[]>([]);
+  const [devisSlots, setDevisSlots] = useState<string[]>([]);
   const [month, setMonth] = useState(() => new Date(new Date().getFullYear(), new Date().getMonth(), 1));
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
@@ -44,6 +49,9 @@ export default function ProDashboard() {
         setPro(pro);
         try {
           setDates(JSON.parse(pro.datesJson) || []);
+        } catch {}
+        try {
+          setDevisSlots(JSON.parse(pro.devisSlotsJson) || []);
         } catch {}
       })
       .catch(() => {});
@@ -89,6 +97,7 @@ export default function ProDashboard() {
         status: pro.status,
         note: pro.note,
         dates,
+        devisSlots,
       }),
     });
     setSaving(false);
@@ -132,6 +141,40 @@ export default function ProDashboard() {
               >
                 <span className="h-3.5 w-3.5 rounded-full" style={{ background: meta.dot }} />
                 {meta.label}
+              </button>
+            );
+          })}
+        </div>
+      </section>
+
+      {/* Créneaux devis (fin de journée, toutes les 30 min) */}
+      <section className="card mt-4 space-y-3">
+        <div className="flex items-center justify-between">
+          <h2 className="font-bold">Créneaux devis</h2>
+          <span className="text-sm text-leaf-800/60">{devisSlots.length} validé(s)</span>
+        </div>
+        <p className="text-sm text-leaf-800/70">
+          Validez les horaires de fin de journée où vous pouvez assurer une visite devis.
+        </p>
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+          {DEVIS_SLOTS.map((t) => {
+            const on = devisSlots.includes(t);
+            return (
+              <button
+                key={t}
+                type="button"
+                onClick={() =>
+                  setDevisSlots((prev) =>
+                    prev.includes(t) ? prev.filter((x) => x !== t) : [...prev, t].sort()
+                  )
+                }
+                className={`rounded-xl border py-3 text-sm font-semibold transition ${
+                  on
+                    ? "border-leaf-600 bg-leaf-600 text-white"
+                    : "border-leaf-200 bg-white text-leaf-900"
+                }`}
+              >
+                {t.replace(":", "h")}
               </button>
             );
           })}


### PR DESCRIPTION
Dans l'espace professionnel, nouvelle section « Créneaux devis » : le pro valide les horaires de fin de journée où il peut assurer une visite devis, par pas de 30 minutes (16h30, 17h00, … 19h30). Les créneaux validés apparaissent dans la vue gérant « Professionnels ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_