### PR TITLE
Chantiers : demi-journée 8h-12h ou journée entière

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,9 @@ paramètre `url` de l'outil Artifact.
 
 **Règle : toute modification visuelle/texte se fait aux DEUX endroits — l'app
 réelle (`app/`) ET la démo — puis commit + push + republication de l'artifact.**
+La démo est un site « une seule page » sans onglets artificiels (choix du
+client) : navigation intégrée comme le vrai site — « Se connecter » en haut
+(→ choix particulier/pro), « Espace gérant » dans le pied de page.
 
 ## Conventions
 

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -18,9 +18,20 @@ type Booking = {
   projectType: string;
   description: string;
   startAt: string;
+  endAt: string;
   status: string;
   photos: Photo[];
 };
+
+/** Libellé de la formule chantier, déduit des heures (fin à 12h = demi-journée). */
+function chantierLabel(b: Booking): string {
+  const endH = new Date(b.endAt).toLocaleTimeString("fr-FR", {
+    timeZone: "Europe/Paris",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  return endH === "12:00" ? "Demi-journée (8h-12h)" : `Journée entière (8h → ${endH.replace(":", "h")})`;
+}
 type Lead = { id: string; name: string; phone: string; email: string; postalCode: string; message: string; createdAt: string };
 
 const STATUS_OPTIONS = [
@@ -145,6 +156,7 @@ export default function AdminDashboard() {
                     ✉️ <a className="text-leaf-700 underline" href={`mailto:${b.email}`}>{b.email}</a>
                   </p>
                   <p>📍 {b.address}, {b.postalCode} {b.city}</p>
+                  {b.kind === "chantier" && <p>🕗 {chantierLabel(b)}</p>}
                   {b.description && <p className="rounded-xl bg-sand-50 p-3">{b.description}</p>}
                   {b.photos.length > 0 && (
                     <div className="flex gap-2">

--- a/app/src/app/admin/parametres/page.tsx
+++ b/app/src/app/admin/parametres/page.tsx
@@ -376,20 +376,11 @@ export default function AdminSettingsPage() {
           </div>
           {s.chantierEnabled && (
             <>
-              <div>
-                <label className="label">Durée d&apos;une intervention (min)</label>
-                <input
-                  className="input max-w-[8rem]"
-                  type="number"
-                  min={30}
-                  step={30}
-                  value={s.chantierDurationMin}
-                  onChange={(e) => set({ chantierDurationMin: Number(e.target.value) })}
-                />
-                <p className="mt-1 text-xs text-leaf-800/60">
-                  120 = 2 h, 240 = demi-journée, 480 = journée entière.
-                </p>
-              </div>
+              <p className="text-sm text-leaf-800/70">
+                Le client choisit un jour puis une formule : <b>demi-journée (8h → 12h)</b> ou{" "}
+                <b>journée entière</b> (8h → fin d&apos;horaire). Tous les chantiers commencent
+                à l&apos;heure d&apos;ouverture ci-dessous.
+              </p>
               <div className="space-y-2">
                 <span className="label">Horaires des chantiers (en journée, dès 8h)</span>
                 {[1, 2, 3, 4, 5, 6, 7].map((d) => {

--- a/app/src/app/annuler/[token]/CancelActions.tsx
+++ b/app/src/app/annuler/[token]/CancelActions.tsx
@@ -18,6 +18,7 @@ export default function CancelActions({
   const [cancelled, setCancelled] = useState(alreadyCancelled);
   const [rescheduling, setRescheduling] = useState(false);
   const [slot, setSlot] = useState<string | null>(null);
+  const [chantierDuration, setChantierDuration] = useState<"demi" | "journee" | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
 
@@ -47,7 +48,7 @@ export default function CancelActions({
       const res = await fetch("/api/bookings/reschedule", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, startAt: slot }),
+        body: JSON.stringify({ token, startAt: slot, chantierDuration }),
       });
       const data = await res.json();
       if (res.ok) {
@@ -57,6 +58,7 @@ export default function CancelActions({
       if (data.error === "creneau_indisponible") {
         setError("Ce créneau vient d'être pris. Choisissez-en un autre.");
         setSlot(null);
+        setChantierDuration(null);
       } else {
         setError("Impossible de déplacer ce rendez-vous. Appelez-nous directement.");
       }
@@ -84,7 +86,15 @@ export default function CancelActions({
     return (
       <div className="mt-6 space-y-4">
         <h2 className="text-lg font-bold">Choisissez votre nouveau créneau</h2>
-        <SlotPicker selected={slot} onSelect={setSlot} token={token} />
+        <SlotPicker
+          selected={slot}
+          selectedDuration={chantierDuration}
+          onSelect={(iso, duration) => {
+            setSlot(iso);
+            setChantierDuration(duration ?? null);
+          }}
+          token={token}
+        />
         {error && <p className="text-sm text-red-600">{error}</p>}
         <div className="flex flex-col gap-2">
           <button className="btn-primary" disabled={!slot || busy} onClick={reschedule}>

--- a/app/src/app/api/availability/route.ts
+++ b/app/src/app/api/availability/route.ts
@@ -1,11 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSettings } from "@/lib/settings";
-import { getAvailability } from "@/lib/availability";
+import { getAvailability, getChantierAvailability } from "@/lib/availability";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/availability?kind=devis|chantier → [{ date, slots }]
+// GET /api/availability?kind=devis|chantier
+//  - devis    → { kind: "devis", days: [{ date, slots: [ISO...] }] }
+//  - chantier → { kind: "chantier", days: [{ date, startAt, demi, journee }] }
 // ?token=... (lien d'annulation) : exclut le RDV du client pour un report.
 export async function GET(req: NextRequest) {
   const settings = await getSettings();
@@ -21,6 +23,10 @@ export async function GET(req: NextRequest) {
       kind = booking.kind === "chantier" ? "chantier" : "devis";
     }
   }
-  const days = await getAvailability(settings, { kind, excludeBookingId: excludeId });
-  return NextResponse.json({ days });
+  if (kind === "chantier") {
+    const days = await getChantierAvailability(settings, excludeId);
+    return NextResponse.json({ kind, days });
+  }
+  const days = await getAvailability(settings, excludeId);
+  return NextResponse.json({ kind, days });
 }

--- a/app/src/app/api/bookings/reschedule/route.ts
+++ b/app/src/app/api/bookings/reschedule/route.ts
@@ -1,7 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSettings } from "@/lib/settings";
-import { isSlotAvailable, durationFor, type BookingKind } from "@/lib/availability";
+import {
+  isSlotAvailable,
+  checkChantier,
+  type ChantierDuration,
+} from "@/lib/availability";
 import { createCalendarEvent, deleteCalendarEvent } from "@/lib/google";
 import { sendConfirmation } from "@/lib/notifications";
 
@@ -14,10 +18,12 @@ export const maxDuration = 30;
 export async function POST(req: NextRequest) {
   let token = "";
   let startAtRaw = "";
+  let chantierDuration: ChantierDuration = "demi";
   try {
     const body = await req.json();
     token = String(body.token ?? "");
     startAtRaw = String(body.startAt ?? "");
+    if (body.chantierDuration === "journee") chantierDuration = "journee";
   } catch {}
   if (!token || !startAtRaw) {
     return NextResponse.json({ error: "token et startAt requis" }, { status: 400 });
@@ -34,12 +40,19 @@ export async function POST(req: NextRequest) {
   }
 
   const settings = await getSettings();
-  const kind = (booking.kind === "chantier" ? "chantier" : "devis") as BookingKind;
-  if (!(await isSlotAvailable(settings, startAt, { kind, excludeBookingId: booking.id }))) {
-    return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+  let endAt: Date;
+  if (booking.kind === "chantier") {
+    const chantierEnd = await checkChantier(settings, startAt, chantierDuration, booking.id);
+    if (!chantierEnd) {
+      return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+    }
+    endAt = chantierEnd;
+  } else {
+    if (!(await isSlotAvailable(settings, startAt, booking.id))) {
+      return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+    }
+    endAt = new Date(startAt.getTime() + settings.visitDurationMin * 60_000);
   }
-
-  const endAt = new Date(startAt.getTime() + durationFor(settings, kind) * 60_000);
 
   // Libère l'ancien événement Google avant d'enregistrer le nouveau créneau.
   await deleteCalendarEvent(settings, booking.googleEventId);

--- a/app/src/app/api/bookings/route.ts
+++ b/app/src/app/api/bookings/route.ts
@@ -2,7 +2,12 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { getSettings } from "@/lib/settings";
 import { checkZone } from "@/lib/zone";
-import { isSlotAvailable, durationFor, type BookingKind } from "@/lib/availability";
+import {
+  isSlotAvailable,
+  checkChantier,
+  type BookingKind,
+  type ChantierDuration,
+} from "@/lib/availability";
 import { createCalendarEvent } from "@/lib/google";
 import { sendConfirmation } from "@/lib/notifications";
 
@@ -29,6 +34,8 @@ export async function POST(req: NextRequest) {
   const city = String(body.city ?? "").trim();
   const projectType = String(body.projectType ?? "");
   const kind: BookingKind = body.kind === "chantier" ? "chantier" : "devis";
+  const chantierDuration: ChantierDuration =
+    body.chantierDuration === "journee" ? "journee" : "demi";
   const description = String(body.description ?? "").slice(0, 2000);
   const startAtRaw = String(body.startAt ?? "");
   const photos = Array.isArray(body.photos) ? (body.photos as string[]).slice(0, 6) : [];
@@ -58,11 +65,20 @@ export async function POST(req: NextRequest) {
   }
 
   // 2. Le créneau est-il toujours libre ? (BDD + Google Agenda)
-  if (!(await isSlotAvailable(settings, startAt, { kind }))) {
-    return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+  // Chantier : jour + formule (demi-journée 8h-12h ou journée entière dès 8h).
+  let endAt: Date;
+  if (kind === "chantier") {
+    const chantierEnd = await checkChantier(settings, startAt, chantierDuration);
+    if (!chantierEnd) {
+      return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+    }
+    endAt = chantierEnd;
+  } else {
+    if (!(await isSlotAvailable(settings, startAt))) {
+      return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+    }
+    endAt = new Date(startAt.getTime() + settings.visitDurationMin * 60_000);
   }
-
-  const endAt = new Date(startAt.getTime() + durationFor(settings, kind) * 60_000);
 
   const booking = await prisma.booking.create({
     data: {

--- a/app/src/components/BookingWizard.tsx
+++ b/app/src/components/BookingWizard.tsx
@@ -25,9 +25,21 @@ export default function BookingWizard({
   chantierEnabled?: boolean;
 }) {
   const router = useRouter();
-  const [kind, setKind] = useState<"devis" | "chantier">("devis");
+  const [kind, setKindRaw] = useState<"devis" | "chantier">("devis");
   const [step, setStep] = useState(1);
   const [projectType, setProjectType] = useState("");
+  const [chantierDuration, setChantierDuration] = useState<"demi" | "journee" | null>(null);
+
+  // Changer de type de RDV remet à zéro le créneau choisi (les horaires diffèrent).
+  function setKind(next: "devis" | "chantier") {
+    setKindRaw((prev) => {
+      if (prev !== next) {
+        setSlot(null);
+        setChantierDuration(null);
+      }
+      return next;
+    });
+  }
 
   // Le 2e bouton du hero (#chantier) préselectionne le rendez-vous chantier.
   useEffect(() => {
@@ -38,6 +50,7 @@ export default function BookingWizard({
     applyHash();
     window.addEventListener("hashchange", applyHash);
     return () => window.removeEventListener("hashchange", applyHash);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chantierEnabled]);
   const [description, setDescription] = useState("");
   const [photos, setPhotos] = useState<string[]>([]);
@@ -104,6 +117,7 @@ export default function BookingWizard({
           postalCode: addr.postalCode,
           city: addr.city,
           kind,
+          chantierDuration,
           projectType,
           description,
           photos,
@@ -119,6 +133,7 @@ export default function BookingWizard({
       if (data.error === "creneau_indisponible") {
         setError("Ce créneau vient d'être réservé. Choisissez-en un autre.");
         setSlot(null);
+        setChantierDuration(null);
       } else if (data.error === "hors_zone") {
         setOutOfZone(true);
       } else {
@@ -331,14 +346,26 @@ export default function BookingWizard({
           </h3>
           <p className="text-sm text-leaf-800/70">
             {kind === "chantier"
-              ? "Interventions en journée, à partir de 8h. Seuls les créneaux disponibles sont affichés."
+              ? "Tous les chantiers commencent à 8h00 : demi-journée (8h-12h) ou journée entière."
               : "Seuls les créneaux réellement disponibles sont affichés."}
           </p>
-          <SlotPicker selected={slot} onSelect={setSlot} kind={kind} />
+          <SlotPicker
+            selected={slot}
+            selectedDuration={chantierDuration}
+            onSelect={(iso, duration) => {
+              setSlot(iso);
+              setChantierDuration(duration ?? null);
+            }}
+            kind={kind}
+          />
           {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex flex-col gap-2 sm:flex-row">
             <button className="btn-secondary" onClick={() => setStep(2)}>← Retour</button>
-            <button className="btn-primary" disabled={!slot || busy} onClick={submitBooking}>
+            <button
+              className="btn-primary"
+              disabled={!slot || (kind === "chantier" && !chantierDuration) || busy}
+              onClick={submitBooking}
+            >
               {busy ? "Réservation…" : "Confirmer mon RDV ✓"}
             </button>
           </div>

--- a/app/src/components/SlotPicker.tsx
+++ b/app/src/components/SlotPicker.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-// Calendrier de créneaux (style Calendly/Planity) : uniquement les disponibilités réelles.
+// Calendrier de réservation (style Calendly/Planity), uniquement les disponibilités réelles.
+// - devis : jours + créneaux de 30 min en fin de journée
+// - chantier : jours + formule « Demi-journée (8h-12h) » ou « Journée entière » (début 8h)
 import { useEffect, useState } from "react";
 
-type DaySlots = { date: string; slots: string[] };
+type DevisDay = { date: string; slots: string[] };
+type ChantierDay = { date: string; startAt: string; demi: boolean; journee: boolean };
 
 function dayLabel(dateStr: string): { weekday: string; day: string } {
   const d = new Date(`${dateStr}T12:00:00`);
@@ -26,15 +29,20 @@ export default function SlotPicker({
   onSelect,
   token,
   kind = "devis",
+  selectedDuration = null,
 }: {
   selected: string | null;
-  onSelect: (iso: string) => void;
+  /** devis : onSelect(iso). chantier : onSelect(iso du jour à 8h, "demi"|"journee"). */
+  onSelect: (iso: string, duration?: "demi" | "journee") => void;
   /** Lien d'annulation : exclut le RDV du client du calcul (report). */
   token?: string;
   /** Type de rendez-vous (devis = fin de journée, chantier = journée dès 8h). */
   kind?: "devis" | "chantier";
+  /** Chantier : formule actuellement sélectionnée. */
+  selectedDuration?: "demi" | "journee" | null;
 }) {
-  const [days, setDays] = useState<DaySlots[] | null>(null);
+  const [mode, setMode] = useState<"devis" | "chantier">(kind);
+  const [days, setDays] = useState<(DevisDay | ChantierDay)[] | null>(null);
   const [activeDay, setActiveDay] = useState<string | null>(null);
   const [error, setError] = useState(false);
 
@@ -46,6 +54,7 @@ export default function SlotPicker({
     fetch(`/api/availability?${params.toString()}`)
       .then((r) => r.json())
       .then((data) => {
+        setMode(data.kind === "chantier" ? "chantier" : "devis");
         setDays(data.days ?? []);
         if (data.days?.length) setActiveDay(data.days[0].date);
       })
@@ -66,7 +75,7 @@ export default function SlotPicker({
   if (days.length === 0) {
     return (
       <p className="py-6 text-sm text-leaf-800/70">
-        Aucun créneau disponible pour le moment. Réessayez un peu plus tard ou appelez-nous.
+        Aucune disponibilité pour le moment. Réessayez un peu plus tard ou appelez-nous.
       </p>
     );
   }
@@ -96,22 +105,69 @@ export default function SlotPicker({
           );
         })}
       </div>
-      <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-        {current.slots.map((iso) => (
-          <button
-            key={iso}
-            type="button"
-            onClick={() => onSelect(iso)}
-            className={`rounded-xl border py-3 text-sm font-semibold transition ${
-              selected === iso
-                ? "border-leaf-600 bg-leaf-600 text-white"
-                : "border-leaf-200 bg-white text-leaf-900 active:bg-leaf-50"
-            }`}
-          >
-            {timeLabel(iso)}
-          </button>
-        ))}
-      </div>
+
+      {mode === "devis" ? (
+        <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
+          {(current as DevisDay).slots.map((iso) => (
+            <button
+              key={iso}
+              type="button"
+              onClick={() => onSelect(iso)}
+              className={`rounded-xl border py-3 text-sm font-semibold transition ${
+                selected === iso
+                  ? "border-leaf-600 bg-leaf-600 text-white"
+                  : "border-leaf-200 bg-white text-leaf-900 active:bg-leaf-50"
+              }`}
+            >
+              {timeLabel(iso)}
+            </button>
+          ))}
+        </div>
+      ) : (
+        <div className="grid gap-2">
+          {(() => {
+            const day = current as ChantierDay;
+            const isOn = (dur: "demi" | "journee") =>
+              selected === day.startAt && selectedDuration === dur;
+            return (
+              <>
+                {day.demi && (
+                  <button
+                    type="button"
+                    onClick={() => onSelect(day.startAt, "demi")}
+                    className={`rounded-xl border px-4 py-3.5 text-left transition ${
+                      isOn("demi")
+                        ? "border-leaf-600 bg-leaf-600 text-white"
+                        : "border-leaf-200 bg-white text-leaf-900 active:bg-leaf-50"
+                    }`}
+                  >
+                    <span className="block text-sm font-bold">Demi-journée</span>
+                    <span className={`block text-sm ${isOn("demi") ? "text-white/80" : "text-leaf-800/60"}`}>
+                      8h00 → 12h00
+                    </span>
+                  </button>
+                )}
+                {day.journee && (
+                  <button
+                    type="button"
+                    onClick={() => onSelect(day.startAt, "journee")}
+                    className={`rounded-xl border px-4 py-3.5 text-left transition ${
+                      isOn("journee")
+                        ? "border-leaf-600 bg-leaf-600 text-white"
+                        : "border-leaf-200 bg-white text-leaf-900 active:bg-leaf-50"
+                    }`}
+                  >
+                    <span className="block text-sm font-bold">Journée entière</span>
+                    <span className={`block text-sm ${isOn("journee") ? "text-white/80" : "text-leaf-800/60"}`}>
+                      Début à 8h00
+                    </span>
+                  </button>
+                )}
+              </>
+            );
+          })()}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/lib/availability.ts
+++ b/app/src/lib/availability.ts
@@ -8,11 +8,9 @@ import { parisTimeToUtc, utcToParis, addDaysStr, todayParis } from "./dates";
 
 export type DaySlots = { date: string; slots: string[] }; // slots = ISO UTC des débuts
 export type BookingKind = "devis" | "chantier";
-
-/** Durée (min) d'un RDV selon son type. */
-export function durationFor(settings: Settings, kind: BookingKind): number {
-  return kind === "chantier" ? settings.chantierDurationMin : settings.visitDurationMin;
-}
+export type ChantierDuration = "demi" | "journee";
+// Un jour de chantier : démarrage unique à 8h, en demi-journée (8h-12h) ou journée entière.
+export type ChantierDay = { date: string; startAt: string; demi: boolean; journee: boolean };
 
 type Interval = { start: Date; end: Date };
 
@@ -20,32 +18,13 @@ function overlaps(a: Interval, b: Interval): boolean {
   return a.start < b.end && a.end > b.start;
 }
 
-/**
- * Renvoie les créneaux libres pour les `maxDaysAhead` prochains jours.
- * Chaque créneau réserve [début - buffer, fin + buffer] pour le trajet.
- * `excludeBookingId` : RDV à ignorer (cas du report — son propre créneau
- * ne doit pas bloquer le choix du nouveau).
- */
-export async function getAvailability(
+/** Périodes occupées (RDV actifs en BDD + Google Agenda) sur la fenêtre de réservation. */
+async function getBusy(
   settings: Settings,
-  opts: { kind?: BookingKind; excludeBookingId?: string } = {}
-): Promise<DaySlots[]> {
-  const kind: BookingKind = opts.kind === "chantier" ? "chantier" : "devis";
-  const excludeBookingId = opts.excludeBookingId;
-  // Devis : horaires de fin de journée. Chantier : horaires de journée (matin 8h).
-  const openingHours = kind === "chantier" ? parseChantierHours(settings) : parseOpeningHours(settings);
-  const daysOff = parseDaysOff(settings);
-  const duration = durationFor(settings, kind);
-  const buffer = settings.bufferMin;
-  // Pas d'affichage des créneaux : toutes les 30 min pour un chantier long,
-  // sinon au pas de la durée de visite (30 min pour un devis).
-  const step = kind === "chantier" ? 30 : duration;
-
-  const startDay = todayParis();
-  const rangeStart = new Date();
-  const rangeEnd = parisTimeToUtc(addDaysStr(startDay, settings.maxDaysAhead), "23:59");
-
-  // Périodes occupées : RDV actifs en BDD + Google Agenda (synchro temps réel).
+  rangeStart: Date,
+  rangeEnd: Date,
+  excludeBookingId?: string
+): Promise<Interval[]> {
   const [bookings, googleBusy] = await Promise.all([
     prisma.booking.findMany({
       where: {
@@ -58,10 +37,31 @@ export async function getAvailability(
     }),
     getBusyPeriods(settings, rangeStart, rangeEnd),
   ]);
-  const busy: Interval[] = [
-    ...bookings.map((b) => ({ start: b.startAt, end: b.endAt })),
-    ...googleBusy,
-  ];
+  return [...bookings.map((b) => ({ start: b.startAt, end: b.endAt })), ...googleBusy];
+}
+
+/**
+ * Créneaux DEVIS : visites de fin de journée, toutes les 30 min.
+ * Chaque créneau réserve [début - buffer, fin + buffer] pour le trajet.
+ * `excludeBookingId` : RDV à ignorer (cas du report — son propre créneau
+ * ne doit pas bloquer le choix du nouveau).
+ */
+export async function getAvailability(
+  settings: Settings,
+  excludeBookingId?: string
+): Promise<DaySlots[]> {
+  const openingHours = parseOpeningHours(settings);
+  const daysOff = parseDaysOff(settings);
+  const duration = settings.visitDurationMin;
+  const buffer = settings.bufferMin;
+  // Créneaux proposés au pas de la durée de visite (ex. toutes les 30 min) ;
+  // le buffer n'espace pas l'affichage, il bloque les voisins d'un RDV pris.
+  const step = duration;
+
+  const startDay = todayParis();
+  const rangeStart = new Date();
+  const rangeEnd = parisTimeToUtc(addDaysStr(startDay, settings.maxDaysAhead), "23:59");
+  const busy = await getBusy(settings, rangeStart, rangeEnd, excludeBookingId);
 
   const minStart = new Date(Date.now() + settings.minNoticeHours * 3600_000);
   const result: DaySlots[] = [];
@@ -97,13 +97,86 @@ export async function getAvailability(
   return result;
 }
 
-/** Revérifie qu'un créneau précis est toujours libre (anti double-booking à la soumission). */
+/** Revérifie qu'un créneau devis précis est toujours libre (anti double-booking à la soumission). */
 export async function isSlotAvailable(
   settings: Settings,
   startAt: Date,
-  opts: { kind?: BookingKind; excludeBookingId?: string } = {}
+  excludeBookingId?: string
 ): Promise<boolean> {
-  const days = await getAvailability(settings, opts);
+  const days = await getAvailability(settings, excludeBookingId);
   const iso = startAt.toISOString();
   return days.some((d) => d.slots.includes(iso));
+}
+
+/**
+ * Jours CHANTIER : tous les chantiers commencent à l'heure d'ouverture (8h00).
+ * Pour chaque jour ouvert, deux formules possibles si l'agenda est libre :
+ * demi-journée (8h → 12h) ou journée entière (8h → fin d'horaire).
+ */
+export async function getChantierAvailability(
+  settings: Settings,
+  excludeBookingId?: string
+): Promise<ChantierDay[]> {
+  const hours = parseChantierHours(settings);
+  const daysOff = parseDaysOff(settings);
+  const buffer = settings.bufferMin;
+
+  const startDay = todayParis();
+  const rangeStart = new Date();
+  const rangeEnd = parisTimeToUtc(addDaysStr(startDay, settings.maxDaysAhead), "23:59");
+  const busy = await getBusy(settings, rangeStart, rangeEnd, excludeBookingId);
+
+  const minStart = new Date(Date.now() + settings.minNoticeHours * 3600_000);
+  const result: ChantierDay[] = [];
+
+  for (let i = 0; i <= settings.maxDaysAhead; i++) {
+    const dateStr = addDaysStr(startDay, i);
+    const weekday = utcToParis(parisTimeToUtc(dateStr, "12:00")).weekday;
+    const dayConfig = hours[String(weekday)];
+    if (!dayConfig?.enabled) continue;
+    if (daysOff.some((d) => dateStr >= d.from && dateStr <= d.to)) continue;
+
+    const start = parisTimeToUtc(dateStr, dayConfig.start); // 08:00
+    if (start < minStart) continue;
+    const demiEnd = parisTimeToUtc(dateStr, "12:00");
+    const fullEnd = parisTimeToUtc(dateStr, dayConfig.end);
+
+    const free = (end: Date) =>
+      end > start &&
+      !busy.some((b) =>
+        overlaps(
+          { start: new Date(start.getTime() - buffer * 60_000), end: new Date(end.getTime() + buffer * 60_000) },
+          b
+        )
+      );
+
+    const demi = free(demiEnd);
+    const journee = free(fullEnd);
+    if (demi || journee) {
+      result.push({ date: dateStr, startAt: start.toISOString(), demi, journee });
+    }
+  }
+  return result;
+}
+
+/**
+ * Valide un chantier (jour + formule) et renvoie sa fin, ou null si indisponible.
+ */
+export async function checkChantier(
+  settings: Settings,
+  startAt: Date,
+  duration: ChantierDuration,
+  excludeBookingId?: string
+): Promise<Date | null> {
+  const days = await getChantierAvailability(settings, excludeBookingId);
+  const day = days.find((d) => d.startAt === startAt.toISOString());
+  if (!day) return null;
+  if (duration === "demi" && !day.demi) return null;
+  if (duration === "journee" && !day.journee) return null;
+  const hours = parseChantierHours(settings);
+  const weekday = utcToParis(parisTimeToUtc(day.date, "12:00")).weekday;
+  const dayConfig = hours[String(weekday)];
+  return duration === "demi"
+    ? parisTimeToUtc(day.date, "12:00")
+    : parisTimeToUtc(day.date, dayConfig?.end ?? "18:00");
 }


### PR DESCRIPTION
Refonte de la réservation des rendez-vous chantier : le client choisit un **jour**, puis une **formule** — « Demi-journée (8h00 → 12h00) » ou « Journée entière » — tous les chantiers commençant à 8h00.

- Le calendrier chantier affiche les jours disponibles avec les formules possibles (une formule disparaît si l'agenda est occupé sur sa plage).
- Un chantier réservé bloque le jour entier pour les autres chantiers (démarrage unique à 8h) sans toucher aux créneaux devis du soir.
- Le report d'un chantier repropose les mêmes formules ; changer de type de RDV dans le tunnel remet à zéro le créneau choisi.
- Tableau de bord gérant : la formule est affichée sur chaque chantier ; le réglage de durée devenu inutile est retiré des paramètres.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_