### PR TITLE
Chantiers sur un ou plusieurs jours

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,10 @@ Docs : `app/ARCHITECTURE.md`.
 
 ## Espaces & comptes
 
-- **Réservation client** : sans compte (parcours 60 s), 2 types de RDV (devis
-  fin de journée 16h30-20h ; chantier en journée dès 8h, durée 2h par défaut).
+- **Réservation client** : sans compte (parcours 60 s), 2 types de RDV — devis
+  fin de journée 16h30-20h (créneaux 30 min) ; chantier : le client choisit un
+  **jour** puis une **formule** « demi-journée 8h-12h » ou « journée entière »,
+  tous les chantiers commencent à 8h00 (un seul chantier par jour).
 - **Comptes particuliers** (`/compte`, inscription libre) : retrouvent leurs RDV
   par email (même ceux réservés sans compte), modifier/annuler.
 - **Espace professionnel** (`/pro`, inscription libre) : statut de dispo (🟢 devis

--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -66,6 +66,9 @@ model Booking {
   lat            Float?
   lng            Float?
   kind           String    @default("devis") // devis | chantier
+  // Chantier multi-jours : les RDV d'un même groupe partagent le groupId
+  // (= id du RDV principal, qui porte le lien d'annulation et les photos).
+  groupId        String    @default("")
   projectType    String // entretien | taille_haie | debroussaillage | contrat_annuel | autre
   description    String    @default("")
   startAt        DateTime

--- a/app/src/app/annuler/[token]/CancelActions.tsx
+++ b/app/src/app/annuler/[token]/CancelActions.tsx
@@ -5,22 +5,30 @@
 import { useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import SlotPicker from "@/components/SlotPicker";
+import SlotPicker, { type ChantierSelection } from "@/components/SlotPicker";
 
 export default function CancelActions({
   token,
   alreadyCancelled,
+  isGroup = false,
 }: {
   token: string;
   alreadyCancelled: boolean;
+  /** Chantier multi-jours : annulation groupée uniquement (pas de report jour par jour). */
+  isGroup?: boolean;
 }) {
   const router = useRouter();
   const [cancelled, setCancelled] = useState(alreadyCancelled);
   const [rescheduling, setRescheduling] = useState(false);
   const [slot, setSlot] = useState<string | null>(null);
-  const [chantierDuration, setChantierDuration] = useState<"demi" | "journee" | null>(null);
+  const [chantierSel, setChantierSel] = useState<ChantierSelection>({ days: [], duration: null });
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+
+  // Report d'un chantier : un seul nouveau jour à la fois.
+  const newStart = slot ?? chantierSel.days[0] ?? null;
+  const canConfirm =
+    Boolean(slot) || (chantierSel.days.length === 1 && Boolean(chantierSel.duration));
 
   async function cancel() {
     setBusy(true);
@@ -41,14 +49,14 @@ export default function CancelActions({
   }
 
   async function reschedule() {
-    if (!slot) return;
+    if (!newStart) return;
     setBusy(true);
     setError("");
     try {
       const res = await fetch("/api/bookings/reschedule", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, startAt: slot, chantierDuration }),
+        body: JSON.stringify({ token, startAt: newStart, chantierDuration: chantierSel.duration }),
       });
       const data = await res.json();
       if (res.ok) {
@@ -58,7 +66,7 @@ export default function CancelActions({
       if (data.error === "creneau_indisponible") {
         setError("Ce créneau vient d'être pris. Choisissez-en un autre.");
         setSlot(null);
-        setChantierDuration(null);
+        setChantierSel({ days: [], duration: null });
       } else {
         setError("Impossible de déplacer ce rendez-vous. Appelez-nous directement.");
       }
@@ -88,16 +96,19 @@ export default function CancelActions({
         <h2 className="text-lg font-bold">Choisissez votre nouveau créneau</h2>
         <SlotPicker
           selected={slot}
-          selectedDuration={chantierDuration}
-          onSelect={(iso, duration) => {
-            setSlot(iso);
-            setChantierDuration(duration ?? null);
-          }}
+          onSelect={setSlot}
           token={token}
+          chantier={chantierSel}
+          onChantierChange={(sel) =>
+            setChantierSel({
+              days: sel.days.slice(-1),
+              duration: sel.days.length ? sel.duration : null,
+            })
+          }
         />
         {error && <p className="text-sm text-red-600">{error}</p>}
         <div className="flex flex-col gap-2">
-          <button className="btn-primary" disabled={!slot || busy} onClick={reschedule}>
+          <button className="btn-primary" disabled={!canConfirm || busy} onClick={reschedule}>
             {busy ? "Modification…" : "Confirmer le nouveau créneau"}
           </button>
           <button className="btn-secondary" onClick={() => setRescheduling(false)}>
@@ -113,11 +124,18 @@ export default function CancelActions({
 
   return (
     <div className="mt-6 space-y-3">
-      <button className="btn-primary w-full" onClick={() => setRescheduling(true)}>
-        Modifier le rendez-vous (nouveau créneau)
-      </button>
+      {isGroup ? (
+        <p className="rounded-xl bg-leaf-50 p-3 text-sm text-leaf-800">
+          Pour changer les dates de ce chantier de plusieurs jours : annulez-le (tous les
+          jours seront libérés), puis réservez de nouveau avec les nouvelles dates.
+        </p>
+      ) : (
+        <button className="btn-primary w-full" onClick={() => setRescheduling(true)}>
+          Modifier le rendez-vous (nouveau créneau)
+        </button>
+      )}
       <button onClick={cancel} disabled={busy} className="btn-primary w-full !bg-red-600 !shadow-red-600/25">
-        {busy ? "Annulation…" : "Annuler le rendez-vous"}
+        {busy ? "Annulation…" : isGroup ? "Annuler le chantier (tous les jours)" : "Annuler le rendez-vous"}
       </button>
       {error && <p className="text-sm text-red-600">{error}</p>}
       <Link href="/" className="btn-secondary w-full">← Conserver mon rendez-vous</Link>

--- a/app/src/app/annuler/[token]/page.tsx
+++ b/app/src/app/annuler/[token]/page.tsx
@@ -10,19 +10,43 @@ export default async function CancelPage({ params }: { params: { token: string }
   const booking = await prisma.booking.findUnique({ where: { cancelToken: params.token } });
   if (!booking) notFound();
 
+  // Chantier multi-jours : récupère tous les jours du groupe.
+  const primaryId = booking.groupId || booking.id;
+  const group = await prisma.booking.findMany({
+    where: { OR: [{ id: primaryId }, { groupId: primaryId }] },
+    orderBy: { startAt: "asc" },
+    select: { startAt: true },
+  });
+  const isGroup = group.length > 1;
+
   return (
     <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center px-4 py-6">
       <SiteHeader />
       <h1 className="mt-4 text-2xl font-extrabold">Modifier ou annuler votre rendez-vous</h1>
       <div className="card mt-5 space-y-1">
-        <p className="font-semibold">
-          📅 {formatDateFr(booking.startAt)} à {formatTimeFr(booking.startAt)}
-        </p>
+        {isGroup ? (
+          <>
+            <p className="font-semibold">📅 Chantier de {group.length} jours, dès 8h00 :</p>
+            <ul className="ml-5 list-disc text-sm text-leaf-900">
+              {group.map((g, i) => (
+                <li key={i} className="capitalize">{formatDateFr(g.startAt)}</li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p className="font-semibold">
+            📅 {formatDateFr(booking.startAt)} à {formatTimeFr(booking.startAt)}
+          </p>
+        )}
         <p className="text-sm text-leaf-800/80">
           📍 {booking.address}, {booking.postalCode} {booking.city}
         </p>
       </div>
-      <CancelActions token={params.token} alreadyCancelled={booking.status === "annule"} />
+      <CancelActions
+        token={params.token}
+        alreadyCancelled={booking.status === "annule"}
+        isGroup={isGroup}
+      />
     </main>
   );
 }

--- a/app/src/app/api/bookings/cancel/route.ts
+++ b/app/src/app/api/bookings/cancel/route.ts
@@ -5,7 +5,8 @@ import { deleteCalendarEvent } from "@/lib/google";
 
 export const dynamic = "force-dynamic";
 
-// POST /api/bookings/cancel { token } — annule le RDV et libère le créneau Google Agenda.
+// POST /api/bookings/cancel { token } — annule le RDV et libère le créneau
+// Google Agenda. Chantier multi-jours : annule tous les jours du groupe.
 export async function POST(req: NextRequest) {
   let token = "";
   try {
@@ -18,10 +19,16 @@ export async function POST(req: NextRequest) {
   if (booking.status === "annule") return NextResponse.json({ ok: true, already: true });
 
   const settings = await getSettings();
-  await deleteCalendarEvent(settings, booking.googleEventId);
-  await prisma.booking.update({
-    where: { id: booking.id },
+  const primaryId = booking.groupId || booking.id;
+  const group = await prisma.booking.findMany({
+    where: { OR: [{ id: primaryId }, { groupId: primaryId }], status: { not: "annule" } },
+  });
+  for (const b of group) {
+    await deleteCalendarEvent(settings, b.googleEventId);
+  }
+  await prisma.booking.updateMany({
+    where: { OR: [{ id: primaryId }, { groupId: primaryId }] },
     data: { status: "annule", cancelledAt: new Date() },
   });
-  return NextResponse.json({ ok: true });
+  return NextResponse.json({ ok: true, cancelled: group.length });
 }

--- a/app/src/app/api/bookings/reschedule/route.ts
+++ b/app/src/app/api/bookings/reschedule/route.ts
@@ -38,6 +38,13 @@ export async function POST(req: NextRequest) {
   if (booking.status === "annule") {
     return NextResponse.json({ error: "deja_annule" }, { status: 409 });
   }
+  // Chantier multi-jours : pas de report jour par jour — annuler puis re-réserver.
+  const siblingCount = await prisma.booking.count({
+    where: { OR: [{ groupId: booking.id }, ...(booking.groupId ? [{ id: booking.groupId }] : [])] },
+  });
+  if (booking.groupId || siblingCount > 0) {
+    return NextResponse.json({ error: "groupe_multi_jours" }, { status: 409 });
+  }
 
   const settings = await getSettings();
   let endAt: Date;

--- a/app/src/app/api/bookings/route.ts
+++ b/app/src/app/api/bookings/route.ts
@@ -37,7 +37,12 @@ export async function POST(req: NextRequest) {
   const chantierDuration: ChantierDuration =
     body.chantierDuration === "journee" ? "journee" : "demi";
   const description = String(body.description ?? "").slice(0, 2000);
-  const startAtRaw = String(body.startAt ?? "");
+  // Chantier : un ou plusieurs jours (body.days) ; devis : un créneau (body.startAt).
+  const daysRaw: string[] =
+    kind === "chantier" && Array.isArray(body.days) && body.days.length
+      ? (body.days as unknown[]).slice(0, 30).map(String)
+      : [String(body.startAt ?? "")];
+  const startAtRaw = daysRaw[0];
   const photos = Array.isArray(body.photos) ? (body.photos as string[]).slice(0, 6) : [];
 
   if (!firstName || !lastName || !phone || !email || !address || !postalCode) {
@@ -65,35 +70,79 @@ export async function POST(req: NextRequest) {
   }
 
   // 2. Le créneau est-il toujours libre ? (BDD + Google Agenda)
-  // Chantier : jour + formule (demi-journée 8h-12h ou journée entière dès 8h).
-  let endAt: Date;
+  // Chantier : un ou plusieurs jours. Plusieurs jours → journée entière chacun ;
+  // un seul jour → formule choisie (demi-journée 8h-12h ou journée entière).
+  const commonData = {
+    firstName,
+    lastName,
+    phone,
+    email,
+    address,
+    postalCode,
+    city,
+    lat: zone.lat,
+    lng: zone.lng,
+    kind,
+    projectType,
+    description,
+  };
+
   if (kind === "chantier") {
-    const chantierEnd = await checkChantier(settings, startAt, chantierDuration);
-    if (!chantierEnd) {
-      return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+    const days = Array.from(new Set(daysRaw))
+      .map((d) => new Date(d))
+      .sort((a, b) => a.getTime() - b.getTime());
+    if (days.some((d) => isNaN(d.getTime()))) {
+      return NextResponse.json({ error: "Créneau invalide" }, { status: 400 });
     }
-    endAt = chantierEnd;
-  } else {
-    if (!(await isSlotAvailable(settings, startAt))) {
-      return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+    const formula = days.length > 1 ? "journee" : chantierDuration;
+    const ends: Date[] = [];
+    for (const day of days) {
+      const end = await checkChantier(settings, day, formula);
+      if (!end) {
+        return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+      }
+      ends.push(end);
     }
-    endAt = new Date(startAt.getTime() + settings.visitDurationMin * 60_000);
+
+    // RDV principal (lien d'annulation + photos), puis un RDV par jour supplémentaire.
+    const primary = await prisma.booking.create({
+      data: {
+        ...commonData,
+        startAt: days[0],
+        endAt: ends[0],
+        photos: { create: photos.map((dataUrl) => ({ dataUrl })) },
+      },
+    });
+    const siblings = [];
+    for (let i = 1; i < days.length; i++) {
+      siblings.push(
+        await prisma.booking.create({
+          data: { ...commonData, groupId: primary.id, startAt: days[i], endAt: ends[i] },
+        })
+      );
+    }
+
+    // Synchro Google Agenda (un événement par jour)
+    for (const b of [primary, ...siblings]) {
+      const googleEventId = await createCalendarEvent(settings, b);
+      if (googleEventId) {
+        await prisma.booking.update({ where: { id: b.id }, data: { googleEventId } });
+      }
+    }
+
+    // SMS + email de confirmation (dates groupées si plusieurs jours)
+    await sendConfirmation(primary, settings, days);
+    return NextResponse.json({ id: primary.id }, { status: 201 });
   }
+
+  if (!(await isSlotAvailable(settings, startAt))) {
+    return NextResponse.json({ error: "creneau_indisponible" }, { status: 409 });
+  }
+  const endAt = new Date(startAt.getTime() + settings.visitDurationMin * 60_000);
 
   const booking = await prisma.booking.create({
     data: {
-      firstName,
-      lastName,
-      phone,
-      email,
-      address,
-      postalCode,
-      city,
-      lat: zone.lat,
-      lng: zone.lng,
-      kind,
-      projectType,
-      description,
+      ...commonData,
       startAt,
       endAt,
       photos: { create: photos.map((dataUrl) => ({ dataUrl })) },

--- a/app/src/app/confirmation/[id]/page.tsx
+++ b/app/src/app/confirmation/[id]/page.tsx
@@ -11,6 +11,12 @@ export default async function ConfirmationPage({ params }: { params: { id: strin
   const booking = await prisma.booking.findUnique({ where: { id: params.id } });
   if (!booking) notFound();
   const settings = await getSettings();
+  // Chantier multi-jours : tous les jours du groupe.
+  const group = await prisma.booking.findMany({
+    where: { OR: [{ id: booking.id }, { groupId: booking.id }] },
+    orderBy: { startAt: "asc" },
+    select: { startAt: true },
+  });
 
   return (
     <main className="mx-auto flex min-h-screen max-w-lg flex-col items-center justify-center px-4 py-6 text-center">
@@ -24,10 +30,21 @@ export default async function ConfirmationPage({ params }: { params: { id: strin
       </p>
 
       <div className="card mt-6 w-full space-y-2 text-left">
-        <p>
-          <span className="font-semibold">📅 {formatDateFr(booking.startAt)}</span> à{" "}
-          <span className="font-semibold">{formatTimeFr(booking.startAt)}</span>
-        </p>
+        {group.length > 1 ? (
+          <>
+            <p className="font-semibold">📅 Chantier de {group.length} jours, dès 8h00 :</p>
+            <ul className="ml-6 list-disc">
+              {group.map((g, i) => (
+                <li key={i} className="capitalize">{formatDateFr(g.startAt)}</li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p>
+            <span className="font-semibold">📅 {formatDateFr(booking.startAt)}</span> à{" "}
+            <span className="font-semibold">{formatTimeFr(booking.startAt)}</span>
+          </p>
+        )}
         <p>📍 {booking.address}, {booking.postalCode} {booking.city}</p>
         <p>🏢 {settings.companyName} — {settings.companyPhone}</p>
       </div>

--- a/app/src/components/BookingWizard.tsx
+++ b/app/src/components/BookingWizard.tsx
@@ -6,7 +6,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import AddressAutocomplete, { type AddressValue } from "./AddressAutocomplete";
 import PhotoUpload from "./PhotoUpload";
-import SlotPicker from "./SlotPicker";
+import SlotPicker, { type ChantierSelection } from "./SlotPicker";
 import { trackMetaEvent } from "./MetaPixel";
 
 const PROJECT_TYPES = [
@@ -28,14 +28,14 @@ export default function BookingWizard({
   const [kind, setKindRaw] = useState<"devis" | "chantier">("devis");
   const [step, setStep] = useState(1);
   const [projectType, setProjectType] = useState("");
-  const [chantierDuration, setChantierDuration] = useState<"demi" | "journee" | null>(null);
+  const [chantierSel, setChantierSel] = useState<ChantierSelection>({ days: [], duration: null });
 
   // Changer de type de RDV remet à zéro le créneau choisi (les horaires diffèrent).
   function setKind(next: "devis" | "chantier") {
     setKindRaw((prev) => {
       if (prev !== next) {
         setSlot(null);
-        setChantierDuration(null);
+        setChantierSel({ days: [], duration: null });
       }
       return next;
     });
@@ -100,8 +100,12 @@ export default function BookingWizard({
     }
   }
 
+  const chantierReady =
+    chantierSel.days.length > 1 || (chantierSel.days.length === 1 && chantierSel.duration);
+
   async function submitBooking() {
-    if (!slot) return;
+    if (kind === "devis" && !slot) return;
+    if (kind === "chantier" && !chantierReady) return;
     setBusy(true);
     setError("");
     try {
@@ -117,7 +121,8 @@ export default function BookingWizard({
           postalCode: addr.postalCode,
           city: addr.city,
           kind,
-          chantierDuration,
+          chantierDuration: chantierSel.duration,
+          days: kind === "chantier" ? chantierSel.days : undefined,
           projectType,
           description,
           photos,
@@ -133,7 +138,7 @@ export default function BookingWizard({
       if (data.error === "creneau_indisponible") {
         setError("Ce créneau vient d'être réservé. Choisissez-en un autre.");
         setSlot(null);
-        setChantierDuration(null);
+        setChantierSel({ days: [], duration: null });
       } else if (data.error === "hors_zone") {
         setOutOfZone(true);
       } else {
@@ -342,31 +347,33 @@ export default function BookingWizard({
       {step === 3 && (
         <div className="space-y-4">
           <h3 className="text-lg font-bold">
-            {kind === "chantier" ? "Choisissez le jour de l'intervention" : "Choisissez votre créneau"}
+            {kind === "chantier" ? "Choisissez le ou les jours de l'intervention" : "Choisissez votre créneau"}
           </h3>
           <p className="text-sm text-leaf-800/70">
             {kind === "chantier"
-              ? "Tous les chantiers commencent à 8h00 : demi-journée (8h-12h) ou journée entière."
+              ? "Tous les chantiers commencent à 8h00. Un jour : demi-journée (8h-12h) ou journée entière ; plusieurs jours : journée entière chacun."
               : "Seuls les créneaux réellement disponibles sont affichés."}
           </p>
           <SlotPicker
             selected={slot}
-            selectedDuration={chantierDuration}
-            onSelect={(iso, duration) => {
-              setSlot(iso);
-              setChantierDuration(duration ?? null);
-            }}
+            onSelect={setSlot}
             kind={kind}
+            chantier={chantierSel}
+            onChantierChange={setChantierSel}
           />
           {error && <p className="text-sm text-red-600">{error}</p>}
           <div className="flex flex-col gap-2 sm:flex-row">
             <button className="btn-secondary" onClick={() => setStep(2)}>← Retour</button>
             <button
               className="btn-primary"
-              disabled={!slot || (kind === "chantier" && !chantierDuration) || busy}
+              disabled={(kind === "devis" ? !slot : !chantierReady) || busy}
               onClick={submitBooking}
             >
-              {busy ? "Réservation…" : "Confirmer mon RDV ✓"}
+              {busy
+                ? "Réservation…"
+                : kind === "chantier" && chantierSel.days.length > 1
+                  ? `Confirmer (${chantierSel.days.length} jours) ✓`
+                  : "Confirmer mon RDV ✓"}
             </button>
           </div>
           <p className="text-center text-xs text-leaf-800/50">

--- a/app/src/components/SlotPicker.tsx
+++ b/app/src/components/SlotPicker.tsx
@@ -2,11 +2,18 @@
 
 // Calendrier de réservation (style Calendly/Planity), uniquement les disponibilités réelles.
 // - devis : jours + créneaux de 30 min en fin de journée
-// - chantier : jours + formule « Demi-journée (8h-12h) » ou « Journée entière » (début 8h)
+// - chantier : sélection d'UN OU PLUSIEURS jours (départ 8h00).
+//   1 jour → formule « Demi-journée (8h-12h) » ou « Journée entière » ;
+//   plusieurs jours → journée entière pour chacun.
 import { useEffect, useState } from "react";
 
 type DevisDay = { date: string; slots: string[] };
 type ChantierDay = { date: string; startAt: string; demi: boolean; journee: boolean };
+
+export type ChantierSelection = {
+  days: string[]; // ISO des débuts (8h00) des jours choisis
+  duration: "demi" | "journee" | null;
+};
 
 function dayLabel(dateStr: string): { weekday: string; day: string } {
   const d = new Date(`${dateStr}T12:00:00`);
@@ -29,17 +36,19 @@ export default function SlotPicker({
   onSelect,
   token,
   kind = "devis",
-  selectedDuration = null,
+  chantier,
+  onChantierChange,
 }: {
-  selected: string | null;
-  /** devis : onSelect(iso). chantier : onSelect(iso du jour à 8h, "demi"|"journee"). */
-  onSelect: (iso: string, duration?: "demi" | "journee") => void;
+  /** Devis : créneau sélectionné (ISO). */
+  selected?: string | null;
+  /** Devis : sélection d'un créneau. */
+  onSelect?: (iso: string) => void;
   /** Lien d'annulation : exclut le RDV du client du calcul (report). */
   token?: string;
-  /** Type de rendez-vous (devis = fin de journée, chantier = journée dès 8h). */
   kind?: "devis" | "chantier";
-  /** Chantier : formule actuellement sélectionnée. */
-  selectedDuration?: "demi" | "journee" | null;
+  /** Chantier : sélection courante (jours + formule). */
+  chantier?: ChantierSelection;
+  onChantierChange?: (sel: ChantierSelection) => void;
 }) {
   const [mode, setMode] = useState<"devis" | "chantier">(kind);
   const [days, setDays] = useState<(DevisDay | ChantierDay)[] | null>(null);
@@ -80,39 +89,38 @@ export default function SlotPicker({
     );
   }
 
-  const current = days.find((d) => d.date === activeDay) ?? days[0];
-
-  return (
-    <div>
-      <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-3">
-        {days.map((d) => {
-          const { weekday, day } = dayLabel(d.date);
-          const isActive = d.date === current.date;
-          return (
-            <button
-              key={d.date}
-              type="button"
-              onClick={() => setActiveDay(d.date)}
-              className={`flex min-w-[4.5rem] flex-col items-center rounded-xl border px-3 py-2 text-sm transition ${
-                isActive
-                  ? "border-leaf-600 bg-leaf-600 text-white"
-                  : "border-leaf-200 bg-white text-leaf-900"
-              }`}
-            >
-              <span className="capitalize opacity-75">{weekday}</span>
-              <span className="font-semibold capitalize">{day}</span>
-            </button>
-          );
-        })}
-      </div>
-
-      {mode === "devis" ? (
+  // ---------- Mode DEVIS : un jour actif + grille de créneaux ----------
+  if (mode === "devis") {
+    const current = (days as DevisDay[]).find((d) => d.date === activeDay) ?? (days as DevisDay[])[0];
+    return (
+      <div>
+        <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-3">
+          {(days as DevisDay[]).map((d) => {
+            const { weekday, day } = dayLabel(d.date);
+            const isActive = d.date === current.date;
+            return (
+              <button
+                key={d.date}
+                type="button"
+                onClick={() => setActiveDay(d.date)}
+                className={`flex min-w-[4.5rem] flex-col items-center rounded-xl border px-3 py-2 text-sm transition ${
+                  isActive
+                    ? "border-leaf-600 bg-leaf-600 text-white"
+                    : "border-leaf-200 bg-white text-leaf-900"
+                }`}
+              >
+                <span className="capitalize opacity-75">{weekday}</span>
+                <span className="font-semibold capitalize">{day}</span>
+              </button>
+            );
+          })}
+        </div>
         <div className="grid grid-cols-3 gap-2 sm:grid-cols-4">
-          {(current as DevisDay).slots.map((iso) => (
+          {current.slots.map((iso) => (
             <button
               key={iso}
               type="button"
-              onClick={() => onSelect(iso)}
+              onClick={() => onSelect?.(iso)}
               className={`rounded-xl border py-3 text-sm font-semibold transition ${
                 selected === iso
                   ? "border-leaf-600 bg-leaf-600 text-white"
@@ -123,50 +131,110 @@ export default function SlotPicker({
             </button>
           ))}
         </div>
-      ) : (
+      </div>
+    );
+  }
+
+  // ---------- Mode CHANTIER : multi-sélection de jours ----------
+  const sel: ChantierSelection = chantier ?? { days: [], duration: null };
+  const chDays = days as ChantierDay[];
+
+  function toggleDay(d: ChantierDay) {
+    let nextDays: string[];
+    if (sel.days.includes(d.startAt)) {
+      nextDays = sel.days.filter((x) => x !== d.startAt);
+    } else if (!d.journee) {
+      // Jour en demi-journée seulement : sélectionnable uniquement seul.
+      nextDays = [d.startAt];
+    } else {
+      // Ajout : les jours déjà choisis doivent supporter la journée entière.
+      const keep = sel.days.filter((x) => chDays.find((c) => c.startAt === x)?.journee);
+      nextDays = [...keep, d.startAt].sort();
+    }
+    const nextDuration =
+      nextDays.length > 1 ? "journee" : nextDays.length === 1 ? sel.duration : null;
+    onChantierChange?.({ days: nextDays, duration: nextDuration });
+  }
+
+  const single =
+    sel.days.length === 1 ? chDays.find((c) => c.startAt === sel.days[0]) : undefined;
+
+  return (
+    <div>
+      <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-3">
+        {chDays.map((d) => {
+          const { weekday, day } = dayLabel(d.date);
+          const isOn = sel.days.includes(d.startAt);
+          return (
+            <button
+              key={d.date}
+              type="button"
+              onClick={() => toggleDay(d)}
+              className={`relative flex min-w-[4.5rem] flex-col items-center rounded-xl border px-3 py-2 text-sm transition ${
+                isOn
+                  ? "border-leaf-600 bg-leaf-600 text-white"
+                  : "border-leaf-200 bg-white text-leaf-900"
+              }`}
+            >
+              <span className="capitalize opacity-75">{weekday}</span>
+              <span className="font-semibold capitalize">{day}</span>
+              {isOn && (
+                <span className="absolute -right-1.5 -top-1.5 flex h-5 w-5 items-center justify-center rounded-full bg-leaf-800 text-[11px] text-white">
+                  ✓
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+
+      {sel.days.length === 0 && (
+        <p className="py-2 text-sm text-leaf-800/70">
+          Touchez un ou plusieurs jours pour votre chantier.
+        </p>
+      )}
+
+      {sel.days.length === 1 && single && (
         <div className="grid gap-2">
-          {(() => {
-            const day = current as ChantierDay;
-            const isOn = (dur: "demi" | "journee") =>
-              selected === day.startAt && selectedDuration === dur;
-            return (
-              <>
-                {day.demi && (
-                  <button
-                    type="button"
-                    onClick={() => onSelect(day.startAt, "demi")}
-                    className={`rounded-xl border px-4 py-3.5 text-left transition ${
-                      isOn("demi")
-                        ? "border-leaf-600 bg-leaf-600 text-white"
-                        : "border-leaf-200 bg-white text-leaf-900 active:bg-leaf-50"
-                    }`}
-                  >
-                    <span className="block text-sm font-bold">Demi-journée</span>
-                    <span className={`block text-sm ${isOn("demi") ? "text-white/80" : "text-leaf-800/60"}`}>
-                      8h00 → 12h00
-                    </span>
-                  </button>
-                )}
-                {day.journee && (
-                  <button
-                    type="button"
-                    onClick={() => onSelect(day.startAt, "journee")}
-                    className={`rounded-xl border px-4 py-3.5 text-left transition ${
-                      isOn("journee")
-                        ? "border-leaf-600 bg-leaf-600 text-white"
-                        : "border-leaf-200 bg-white text-leaf-900 active:bg-leaf-50"
-                    }`}
-                  >
-                    <span className="block text-sm font-bold">Journée entière</span>
-                    <span className={`block text-sm ${isOn("journee") ? "text-white/80" : "text-leaf-800/60"}`}>
-                      Début à 8h00
-                    </span>
-                  </button>
-                )}
-              </>
-            );
-          })()}
+          {single.demi && (
+            <button
+              type="button"
+              onClick={() => onChantierChange?.({ ...sel, duration: "demi" })}
+              className={`rounded-xl border px-4 py-3.5 text-left transition ${
+                sel.duration === "demi"
+                  ? "border-leaf-600 bg-leaf-600 text-white"
+                  : "border-leaf-200 bg-white text-leaf-900 active:bg-leaf-50"
+              }`}
+            >
+              <span className="block text-sm font-bold">Demi-journée</span>
+              <span className={`block text-sm ${sel.duration === "demi" ? "text-white/80" : "text-leaf-800/60"}`}>
+                8h00 → 12h00
+              </span>
+            </button>
+          )}
+          {single.journee && (
+            <button
+              type="button"
+              onClick={() => onChantierChange?.({ ...sel, duration: "journee" })}
+              className={`rounded-xl border px-4 py-3.5 text-left transition ${
+                sel.duration === "journee"
+                  ? "border-leaf-600 bg-leaf-600 text-white"
+                  : "border-leaf-200 bg-white text-leaf-900 active:bg-leaf-50"
+              }`}
+            >
+              <span className="block text-sm font-bold">Journée entière</span>
+              <span className={`block text-sm ${sel.duration === "journee" ? "text-white/80" : "text-leaf-800/60"}`}>
+                Début à 8h00
+              </span>
+            </button>
+          )}
         </div>
+      )}
+
+      {sel.days.length > 1 && (
+        <p className="rounded-xl bg-leaf-50 p-3 text-sm font-medium text-leaf-800">
+          {sel.days.length} jours sélectionnés — journée entière (début 8h00) pour chaque jour.
+        </p>
       )}
     </div>
   );

--- a/app/src/lib/notifications.ts
+++ b/app/src/lib/notifications.ts
@@ -5,11 +5,16 @@ import { sendEmail } from "./email";
 import { buildIcs } from "./ics";
 import { renderTemplate } from "./templates";
 
-/** SMS + email de confirmation, envoyés immédiatement après la réservation. */
-export async function sendConfirmation(booking: Booking, settings: Settings): Promise<void> {
-  const smsBody = renderTemplate(settings.smsConfirmation, booking, settings);
-  const emailSubject = renderTemplate(settings.emailSubject, booking, settings);
-  const emailBody = renderTemplate(settings.emailBody, booking, settings);
+/** SMS + email de confirmation, envoyés immédiatement après la réservation.
+ *  `groupDates` : chantier multi-jours ({{date}} devient « du … au … »). */
+export async function sendConfirmation(
+  booking: Booking,
+  settings: Settings,
+  groupDates?: Date[]
+): Promise<void> {
+  const smsBody = renderTemplate(settings.smsConfirmation, booking, settings, groupDates);
+  const emailSubject = renderTemplate(settings.emailSubject, booking, settings, groupDates);
+  const emailBody = renderTemplate(settings.emailBody, booking, settings, groupDates);
   await Promise.allSettled([
     sendSms(booking.phone, smsBody),
     sendEmail({

--- a/app/src/lib/templates.ts
+++ b/app/src/lib/templates.ts
@@ -5,12 +5,25 @@ export function appUrl(): string {
   return (process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000").replace(/\/$/, "");
 }
 
-/** Remplace les variables {{...}} d'un modèle de message. */
-export function renderTemplate(template: string, booking: Booking, settings: Settings): string {
+/** Remplace les variables {{...}} d'un modèle de message.
+ *  `groupDates` (chantier multi-jours) : {{date}} devient « du … au … (N jours) ». */
+export function renderTemplate(
+  template: string,
+  booking: Booking,
+  settings: Settings,
+  groupDates?: Date[]
+): string {
+  let dateLabel = formatDateFr(booking.startAt);
+  if (groupDates && groupDates.length > 1) {
+    const sorted = [...groupDates].sort((a, b) => a.getTime() - b.getTime());
+    dateLabel = `du ${formatDateFr(sorted[0])} au ${formatDateFr(sorted[sorted.length - 1])} (${sorted.length} jours)`;
+    // Évite « le du mardi… » : les modèles écrivent « le {{date}} ».
+    template = template.replace(/\b[lL]e\s+(\{\{\s*date\s*\}\})/g, "$1");
+  }
   const vars: Record<string, string> = {
     prenom: booking.firstName,
     nom: booking.lastName,
-    date: formatDateFr(booking.startAt),
+    date: dateLabel,
     heure: formatTimeFr(booking.startAt),
     adresse: `${booking.address}, ${booking.postalCode} ${booking.city}`.trim(),
     entreprise: settings.companyName,


### PR DESCRIPTION
Le client peut désormais sélectionner **un ou plusieurs jours** pour son chantier :

- Le calendrier chantier devient multi-sélection (coche sur chaque jour choisi).
- Plusieurs jours → journée entière pour chacun, départ 8h00 ; un seul jour → choix demi-journée (8h-12h) ou journée entière conservé.
- Un chantier multi-jours est un groupe de RDV liés : un seul SMS de confirmation avec la période (« du mardi 4 août au jeudi 6 août, 3 jours »), un seul lien d'annulation qui libère tous les jours d'un coup, rappels la veille de chaque journée.
- Le report jour par jour d'un groupe est remplacé par un message « annulez puis re-réservez » (plus sûr).
- Les pages de confirmation et d'annulation listent tous les jours du chantier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_