### PR TITLE
Suppression du statut « Indisponible » : la disponibilité, c'est l'agenda

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -146,8 +146,10 @@ model Pro {
   baseCity       String   @default("")
   basePostalCode String   @default("")
   radiusKm       Int      @default(30)
-  // disponible_devis | disponible_chantier | sous_confirmation | indisponible
-  status         String   @default("indisponible")
+  // Dernier onglet ouvert dans « Mes disponibilités » (disponible_devis |
+  // disponible_chantier). N'a plus d'effet sur les attributions : la
+  // disponibilité découle uniquement de datesJson / devisDispoJson.
+  status         String   @default("disponible_chantier")
   // Nombre de journées disponibles annoncées
   availableDays  Int      @default(0)
   // Dates disponibles : ["2026-08-12","2026-08-13",...]

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useState } from "react";
 import ManualBookingModal from "./ManualBookingModal";
 import PhotoUpload from "@/components/PhotoUpload";
+import { parseDates } from "@/lib/proStatus";
 
 type Photo = { id: string; dataUrl: string };
 type Booking = {
@@ -26,7 +27,23 @@ type Booking = {
   pro: { id: string; name: string } | null;
   photos: Photo[];
 };
-type ProLite = { id: string; name: string; basePostalCode: string; radiusKm: number; status: string };
+type ProLite = {
+  id: string;
+  name: string;
+  basePostalCode: string;
+  radiusKm: number;
+  datesJson: string;
+};
+
+/** Jour de Paris (AAAA-MM-JJ) d'une date ISO. */
+function parisDay(iso: string): string {
+  return new Intl.DateTimeFormat("fr-CA", {
+    timeZone: "Europe/Paris",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).format(new Date(iso));
+}
 
 /** Libellé de la formule chantier, déduit des heures (fin à 12h = demi-journée). */
 function chantierLabel(b: Booking): string {
@@ -296,7 +313,9 @@ export default function AdminDashboard() {
                         {pros.map((p) => (
                           <option key={p.id} value={p.id}>
                             {p.name}
-                            {p.status !== "disponible_chantier" ? " (pas dispo chantier)" : ""}
+                            {b.startAt && !parseDates(p.datesJson).includes(parisDay(b.startAt))
+                              ? " (n'a pas déclaré ce jour)"
+                              : ""}
                           </option>
                         ))}
                       </select>

--- a/app/src/app/admin/pros/page.tsx
+++ b/app/src/app/admin/pros/page.tsx
@@ -2,7 +2,7 @@
 
 // Vue gérant : tous les professionnels et leurs disponibilités déclarées.
 import { useEffect, useState } from "react";
-import { PRO_STATUS_META } from "@/lib/proStatus";
+import { dispoResume, parseDispo } from "@/lib/proStatus";
 
 type Pro = {
   id: string;
@@ -13,35 +13,30 @@ type Pro = {
   baseCity: string;
   basePostalCode: string;
   radiusKm: number;
-  status: string;
   availableDays: number;
   datesJson: string;
-  devisSlotsJson: string;
+  devisDispoJson: string;
   note: string;
   updatedAt: string;
 };
 
-function fmtSlots(json: string): string {
-  try {
-    const slots: string[] = JSON.parse(json);
-    if (!slots.length) return "—";
-    return slots.map((s) => s.replace(":", "h")).join(" · ");
-  } catch {
-    return "—";
-  }
+function jourCourt(d: string): string {
+  return new Date(`${d}T12:00:00`).toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
 }
 
-function fmtDates(json: string): string {
-  try {
-    const dates: string[] = JSON.parse(json);
-    if (!dates.length) return "—";
-    return dates
-      .slice(0, 8)
-      .map((d) => new Date(`${d}T12:00:00`).toLocaleDateString("fr-FR", { day: "numeric", month: "short" }))
-      .join(", ") + (dates.length > 8 ? `… (+${dates.length - 8})` : "");
-  } catch {
-    return "—";
-  }
+function fmtJours(days: string[]): string {
+  if (!days.length) return "—";
+  return days.slice(0, 8).map(jourCourt).join(", ") + (days.length > 8 ? `… (+${days.length - 8})` : "");
+}
+
+/** « 13 août : 10h00 · 17h00 » pour chaque jour renseigné. */
+function fmtCreneaux(json: string, days: string[]): string {
+  const dispo = parseDispo(json);
+  if (!days.length) return "—";
+  return days
+    .slice(0, 4)
+    .map((d) => `${jourCourt(d)} : ${dispo[d].map((t) => t.replace(":", "h")).join(" · ")}`)
+    .join(" | ") + (days.length > 4 ? `… (+${days.length - 4} jour(s))` : "");
 }
 
 export default function AdminProsPage() {
@@ -70,7 +65,9 @@ export default function AdminProsPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  const available = pros.filter((p) => p.status !== "indisponible");
+  // « Disponible » = a réellement coché quelque chose à venir dans son agenda.
+  const today = new Date().toISOString().slice(0, 10);
+  const available = pros.filter((p) => dispoResume(p, today).actif);
 
   return (
     <main className="mx-auto max-w-4xl px-4 py-6">
@@ -89,7 +86,7 @@ export default function AdminProsPage() {
 
       <div className="space-y-3">
         {pros.map((p) => {
-          const meta = PRO_STATUS_META[p.status] ?? PRO_STATUS_META.indisponible;
+          const resume = dispoResume(p, today);
           return (
             <div key={p.id} className="card">
               <div className="flex items-start justify-between gap-3">
@@ -105,10 +102,10 @@ export default function AdminProsPage() {
                 </div>
                 <div className="flex flex-col items-end gap-1.5">
                   <span
-                    className={`flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ${meta.badge}`}
+                    className={`flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-semibold ${resume.badge}`}
                   >
-                    <span className="h-2 w-2 rounded-full" style={{ background: meta.dot }} />
-                    {meta.label}
+                    <span className="h-2 w-2 rounded-full" style={{ background: resume.dot }} />
+                    {resume.label}
                   </span>
                   <button
                     onClick={() => removePro(p)}
@@ -124,9 +121,9 @@ export default function AdminProsPage() {
                   {" · "}
                   <a className="text-leaf-700 underline" href={`mailto:${p.email}`}>{p.email}</a>
                 </p>
-                <p>{p.availableDays} journée(s) annoncée(s)</p>
-                <p>{fmtDates(p.datesJson)}</p>
-                <p>Créneaux devis : {fmtSlots(p.devisSlotsJson)}</p>
+                <p className="text-leaf-800/70">{resume.detail}</p>
+                <p>Jours de chantier : {fmtJours(resume.jours)}</p>
+                <p>Créneaux de visite : {fmtCreneaux(p.devisDispoJson, resume.joursDevis)}</p>
                 {p.note && <p className="rounded-xl bg-sand-50 p-3 text-leaf-800/80">{p.note}</p>}
               </div>
             </div>

--- a/app/src/app/api/admin/planning/route.ts
+++ b/app/src/app/api/admin/planning/route.ts
@@ -59,11 +59,10 @@ export async function GET(req: NextRequest) {
         id: true,
         name: true,
         phone: true,
-        status: true,
         radiusKm: true,
         baseCity: true,
         datesJson: true,
-        devisSlotsJson: true,
+        devisDispoJson: true,
       },
     }),
   ]);

--- a/app/src/app/api/pro/planning/route.ts
+++ b/app/src/app/api/pro/planning/route.ts
@@ -56,11 +56,10 @@ export async function GET(req: NextRequest) {
       select: {
         id: true,
         name: true,
-        status: true,
         radiusKm: true,
         baseCity: true,
         datesJson: true,
-        devisSlotsJson: true,
+        devisDispoJson: true,
       },
     }),
   ]);

--- a/app/src/app/pro/disponibilites/page.tsx
+++ b/app/src/app/pro/disponibilites/page.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-// Disponibilités : statut (3 choix), puis selon le statut —
+// Disponibilités : deux agendas, au choix de l'onglet —
 //  - chantier : un tap sur un jour = disponible (vert) ;
 //  - devis : un tap sur un jour ouvre le panneau du jour (créneaux de 30 min
 //    + raccourcis Fin de journée / Matin / Après-midi).
-// Tout s'enregistre immédiatement : aucun bouton « Enregistrer ».
+// Il n'y a pas de bouton « indisponible » : ce qui n'est pas coché n'est pas
+// proposé. Tout s'enregistre immédiatement : aucun bouton « Enregistrer ».
 import { useEffect, useMemo, useRef, useState } from "react";
-import { PRO_STATUS_META, PRO_STATUS_ORDER } from "@/lib/proStatus";
+import { MODE_META, MODE_ORDER, modeOf, statusOfMode, type ProMode } from "@/lib/proStatus";
 import { ymd } from "../shared";
 
 type Pro = {
@@ -39,12 +40,14 @@ function addMonths(d: Date, n: number) {
 
 export default function ProDisponibilitesPage() {
   const [pro, setPro] = useState<Pro | null>(null);
+  const [mode, setMode] = useState<ProMode>("chantier");
   const [dates, setDates] = useState<string[]>([]);
   const [dispo, setDispo] = useState<Record<string, string[]>>({});
   const [month, setMonth] = useState(() => new Date(new Date().getFullYear(), new Date().getMonth(), 1));
   const [jourOuvert, setJourOuvert] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
   const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const enAttente = useRef<Record<string, unknown>>({});
 
   useEffect(() => {
     fetch("/api/pro/me")
@@ -57,6 +60,7 @@ export default function ProDisponibilitesPage() {
       })
       .then(({ pro }) => {
         setPro(pro);
+        setMode(modeOf(pro.status)); // dernier onglet ouvert
         try {
           setDates(JSON.parse(pro.datesJson) || []);
         } catch {}
@@ -68,14 +72,21 @@ export default function ProDisponibilitesPage() {
       .catch(() => {});
   }, []);
 
-  /** Enregistre immédiatement (léger regroupement pour les taps rapprochés). */
+  /**
+   * Enregistre immédiatement (léger regroupement pour les taps rapprochés).
+   * Les patchs en attente sont FUSIONNÉS : cocher un jour puis changer d'onglet
+   * dans la foulée ne doit pas faire perdre le jour coché.
+   */
   function persist(patch: Record<string, unknown>) {
+    enAttente.current = { ...enAttente.current, ...patch };
     if (saveTimer.current) clearTimeout(saveTimer.current);
     saveTimer.current = setTimeout(async () => {
+      const body = enAttente.current;
+      enAttente.current = {};
       const res = await fetch("/api/pro/me", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(patch),
+        body: JSON.stringify(body),
       });
       if (res.ok) {
         setSaved(true);
@@ -84,12 +95,12 @@ export default function ProDisponibilitesPage() {
     }, 400);
   }
 
-  const set = (patch: Partial<Pro>) => setPro((p) => (p ? { ...p, ...patch } : p));
-
-  function changeStatus(id: string) {
-    set({ status: id });
+  /** Changer d'agenda : simple onglet, mémorisé pour la prochaine visite. */
+  function changeMode(next: ProMode) {
+    setMode(next);
     setJourOuvert(null);
-    persist({ status: id });
+    setPro((p) => (p ? { ...p, status: statusOfMode(next) } : p));
+    persist({ status: statusOfMode(next) });
   }
 
   function toggleJourChantier(d: string) {
@@ -122,9 +133,13 @@ export default function ProDisponibilitesPage() {
     return <main className="mx-auto max-w-lg px-4 py-10 text-center text-leaf-800/60">Chargement…</main>;
   }
 
-  const modeDevis = pro.status === "disponible_devis";
-  const modeChantier = pro.status === "disponible_chantier";
+  const modeDevis = mode === "devis";
+  const modeChantier = mode === "chantier";
   const slotsOuverts = jourOuvert ? dispo[jourOuvert] ?? [] : [];
+  const joursAVenir = dates.filter((d) => d >= todayStr).length;
+  const creneauxAVenir = Object.entries(dispo)
+    .filter(([d]) => d >= todayStr)
+    .reduce((n, [, s]) => n + s.length, 0);
 
   return (
     <main className="mx-auto max-w-lg px-4 py-6">
@@ -136,39 +151,49 @@ export default function ProDisponibilitesPage() {
         {saved && <span className="text-sm font-semibold text-leaf-700">✓ Enregistré</span>}
       </div>
 
-      {/* Statut : 3 choix */}
-      <section className="card space-y-2">
-        <h2 className="font-bold">Votre statut</h2>
-        <div className="grid gap-2">
-          {PRO_STATUS_ORDER.map((id) => {
-            const meta = PRO_STATUS_META[id];
-            const active = pro.status === id;
-            return (
-              <button
-                key={id}
-                type="button"
-                onClick={() => changeStatus(id)}
-                className={`flex items-center gap-3 rounded-xl border px-4 py-3 text-left text-sm font-medium transition ${
-                  active ? "border-leaf-600 bg-leaf-50 ring-2 ring-leaf-500/25" : "border-leaf-200 bg-white"
-                }`}
-              >
-                <span className="h-3.5 w-3.5 rounded-full" style={{ background: meta.dot }} />
-                {meta.label}
-              </button>
-            );
-          })}
-        </div>
-      </section>
+      {/* Deux agendas : on choisit celui qu'on remplit. Pas de bouton
+          « indisponible » — ce qui n'est pas coché n'est pas proposé. */}
+      <div className="mb-3 grid grid-cols-2 gap-2 rounded-2xl bg-leaf-50 p-1.5">
+        {MODE_ORDER.map((id) => {
+          const meta = MODE_META[id];
+          const active = mode === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => changeMode(id)}
+              className={`flex items-center justify-center gap-2 rounded-xl px-3 py-2.5 text-sm font-semibold transition ${
+                active ? "bg-white shadow-sm" : "text-leaf-800/60"
+              }`}
+            >
+              <span className="h-2.5 w-2.5 rounded-full" style={{ background: meta.dot }} />
+              {meta.label}
+            </button>
+          );
+        })}
+      </div>
 
-      {pro.status === "indisponible" ? (
-        <p className="card mt-4 py-6 text-center text-sm text-leaf-800/60">
-          Vous êtes indisponible : aucun rendez-vous ne vous sera attribué.
-          <br />
-          Vos dates et créneaux sont conservés — ils réapparaîtront dès que vous
-          redeviendrez disponible.
-        </p>
-      ) : (
-        <section className="card mt-4 space-y-3">
+      <p className="mb-3 rounded-xl bg-sand-50 px-4 py-3 text-sm text-leaf-800/80">
+        Vous recevez uniquement ce que vous cochez ici. Pas besoin de vous déclarer
+        indisponible : un jour non coché n&apos;est jamais proposé aux clients.
+        {(joursAVenir > 0 || creneauxAVenir > 0) && (
+          <>
+            {" "}
+            Actuellement :{" "}
+            <b>
+              {[
+                joursAVenir ? `${joursAVenir} jour(s) de chantier` : "",
+                creneauxAVenir ? `${creneauxAVenir} créneau(x) de visite` : "",
+              ]
+                .filter(Boolean)
+                .join(" et ")}
+            </b>
+            .
+          </>
+        )}
+      </p>
+
+      <section className="card mt-4 space-y-3">
           <div className="flex items-center justify-between">
             <h2 className="font-bold">{modeChantier ? "Mes jours de chantier" : "Mes créneaux de visite"}</h2>
             <span className="text-sm text-leaf-800/60">
@@ -309,8 +334,7 @@ export default function ProDisponibilitesPage() {
               </div>
             </div>
           )}
-        </section>
-      )}
+      </section>
     </main>
   );
 }

--- a/app/src/app/pro/page.tsx
+++ b/app/src/app/pro/page.tsx
@@ -4,7 +4,7 @@
 // aperçu des jours à venir. Le détail vit dans les sections de la barre latérale.
 import { useEffect, useState } from "react";
 import Link from "next/link";
-import { PRO_STATUS_META } from "@/lib/proStatus";
+import { dispoResume } from "@/lib/proStatus";
 import {
   type Mission,
   type EquipeJour,
@@ -18,7 +18,11 @@ import {
 } from "./shared";
 
 export default function ProDashboard() {
-  const [pro, setPro] = useState<{ name: string; status: string } | null>(null);
+  const [pro, setPro] = useState<{
+    name: string;
+    datesJson: string;
+    devisDispoJson: string;
+  } | null>(null);
   const [missions, setMissions] = useState<Mission[]>([]);
   const [equipe, setEquipe] = useState<EquipeJour[]>([]);
   const [heures, setHeures] = useState<{ semaine: number; mois: number } | null>(null);
@@ -45,7 +49,13 @@ export default function ProDashboard() {
         }
         return r.json();
       })
-      .then(({ pro }) => setPro({ name: pro.name, status: pro.status }))
+      .then(({ pro }) =>
+        setPro({
+          name: pro.name,
+          datesJson: pro.datesJson,
+          devisDispoJson: pro.devisDispoJson,
+        })
+      )
       .catch(() => {});
     loadMissions();
   }, []);
@@ -67,7 +77,7 @@ export default function ProDashboard() {
     return <main className="mx-auto max-w-lg px-4 py-10 text-center text-leaf-800/60">Chargement…</main>;
   }
 
-  const statut = PRO_STATUS_META[pro.status] ?? PRO_STATUS_META.indisponible;
+  const resume = dispoResume(pro, ymd(new Date()));
   const prochain = missions[0];
   const apercu = Array.from(new Set([...missions.map((m) => m.day), ...equipe.map((e) => e.day)]))
     .sort()
@@ -107,11 +117,11 @@ export default function ProDashboard() {
           </p>
         </Link>
         <Link href="/pro/disponibilites" className="card !p-3 text-center transition hover:bg-leaf-50">
-          <p className="text-[11px] font-semibold uppercase tracking-wide text-leaf-800/50">Statut</p>
-          <p className="mx-auto mt-1.5 h-5 w-5 rounded-full" style={{ background: statut.dot }} />
-          <p className="mt-1 text-[11px] font-semibold text-leaf-800/80">
-            {statut.label.replace("Disponible pour un ", "").replace("Disponible sous ", "Sous ")}
+          <p className="text-[11px] font-semibold uppercase tracking-wide text-leaf-800/50">
+            Mes dispos
           </p>
+          <p className="mx-auto mt-1.5 h-5 w-5 rounded-full" style={{ background: resume.dot }} />
+          <p className="mt-1 text-[11px] font-semibold text-leaf-800/80">{resume.label}</p>
         </Link>
       </div>
 

--- a/app/src/components/AgendaView.tsx
+++ b/app/src/components/AgendaView.tsx
@@ -4,7 +4,7 @@
 // RDV clients (blocs colorés sur grille horaire) et les dispos des pros.
 // `showContacts` contrôle l'affichage des téléphones (réservé au gérant).
 import { useEffect, useMemo, useState } from "react";
-import { PRO_STATUS_META } from "@/lib/proStatus";
+import { MODE_META, parseDates, parseDispo } from "@/lib/proStatus";
 
 type Booking = {
   id: string;
@@ -22,12 +22,13 @@ type Pro = {
   id: string;
   name: string;
   phone?: string;
-  status: string;
   radiusKm: number;
   baseCity: string;
   datesJson: string;
-  devisSlotsJson: string;
+  devisDispoJson: string;
 };
+/** Un pro sur un jour donné, avec ce qu'il y a déclaré. */
+type ProJour = { pro: Pro; chantier: boolean; creneaux: string[] };
 type View = "mois" | "semaine" | "jour";
 
 // Grille horaire : 7h00 → 20h00 (les chantiers démarrent à 8h, les devis finissent à 20h)
@@ -147,13 +148,24 @@ export default function AgendaView({
     return map;
   }, [bookings]);
 
+  // Un pro est disponible un jour donné s'il l'a coché en chantier ou s'il y a
+  // déclaré des créneaux de visite — il n'y a pas d'autre statut.
   const prosByDay = useMemo(() => {
-    const map: Record<string, Pro[]> = {};
+    const map: Record<string, ProJour[]> = {};
+    const entry = (day: string, p: Pro): ProJour => {
+      const list = (map[day] ??= []);
+      let found = list.find((x) => x.pro.id === p.id);
+      if (!found) {
+        found = { pro: p, chantier: false, creneaux: [] };
+        list.push(found);
+      }
+      return found;
+    };
     for (const p of pros) {
-      if (p.status === "indisponible") continue;
-      try {
-        for (const d of JSON.parse(p.datesJson) as string[]) (map[d] ??= []).push(p);
-      } catch {}
+      for (const d of parseDates(p.datesJson)) entry(d, p).chantier = true;
+      for (const [d, slots] of Object.entries(parseDispo(p.devisDispoJson))) {
+        entry(d, p).creneaux = slots;
+      }
     }
     return map;
   }, [pros]);
@@ -241,9 +253,9 @@ export default function AgendaView({
         <span className="flex flex-wrap justify-center gap-0.5">
           {(prosByDay[day] ?? []).slice(0, 4).map((p) => (
             <span
-              key={p.id}
+              key={p.pro.id}
               className="h-1.5 w-1.5 rounded-sm"
-              style={{ background: PRO_STATUS_META[p.status]?.dot ?? "#999" }}
+              style={{ background: MODE_META[p.chantier ? "chantier" : "devis"].dot }}
             />
           ))}
         </span>
@@ -356,7 +368,7 @@ export default function AgendaView({
       <div className="mb-3 flex flex-wrap gap-3 text-xs text-leaf-800/70">
         <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-full bg-blue-500" /> RDV devis</span>
         <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-full bg-green-500" /> Chantier</span>
-        <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-leaf-200" /> Pro disponible (couleur = statut)</span>
+        <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-leaf-200" /> Pro disponible (vert = chantier, bleu = visites)</span>
       </div>
 
       {loading ? (
@@ -399,9 +411,9 @@ export default function AgendaView({
                         <span className="mt-0.5 flex flex-wrap gap-0.5">
                           {(prosByDay[day] ?? []).slice(0, 4).map((p) => (
                             <span
-                              key={p.id}
+                              key={p.pro.id}
                               className="h-2 w-2 rounded-sm"
-                              style={{ background: PRO_STATUS_META[p.status]?.dot ?? "#999" }}
+                              style={{ background: MODE_META[p.chantier ? "chantier" : "devis"].dot }}
                             />
                           ))}
                         </span>
@@ -461,19 +473,21 @@ export default function AgendaView({
                   </p>
                 ) : (
                   <div className="space-y-2">
-                    {dayPros.map((p) => {
-                      const meta = PRO_STATUS_META[p.status] ?? PRO_STATUS_META.indisponible;
-                      let slots: string[] = [];
-                      try {
-                        slots = (JSON.parse(p.devisSlotsJson) as string[]) ?? [];
-                      } catch {}
+                    {dayPros.map(({ pro: p, chantier, creneaux }) => {
+                      const meta = MODE_META[chantier ? "chantier" : "devis"];
+                      const quoi = [
+                        chantier ? "chantier (journée)" : "",
+                        creneaux.length ? `${creneaux.length} créneau(x) de visite` : "",
+                      ]
+                        .filter(Boolean)
+                        .join(" · ");
                       return (
                         <div key={p.id} className="rounded-xl bg-sand-50 px-3 py-2 text-sm">
                           <div className="flex items-center gap-2">
                             <span className="h-2.5 w-2.5 shrink-0 rounded-full" style={{ background: meta.dot }} />
                             <span className="font-semibold">{p.name}</span>
                             <span className="text-leaf-800/70">
-                              {meta.label} · rayon {p.radiusKm} km
+                              {quoi} · rayon {p.radiusKm} km
                             </span>
                             {showContacts && (
                               <a className="ml-auto text-leaf-700 underline" href={`tel:${p.phone}`}>
@@ -481,10 +495,10 @@ export default function AgendaView({
                               </a>
                             )}
                           </div>
-                          {slots.length > 0 && (
+                          {creneaux.length > 0 && (
                             <div className="mt-1.5 flex flex-wrap items-center gap-1">
-                              <span className="text-xs text-leaf-800/60">Heures devis :</span>
-                              {slots.map((s) => (
+                              <span className="text-xs text-leaf-800/60">Heures de visite :</span>
+                              {creneaux.map((s) => (
                                 <span key={s} className="rounded-md bg-blue-100 px-1.5 py-0.5 text-xs font-semibold text-blue-800">
                                   {s.replace(":", "h")}
                                 </span>

--- a/app/src/lib/assign.ts
+++ b/app/src/lib/assign.ts
@@ -1,6 +1,7 @@
 // Attribution automatique des chantiers au professionnel disponible le plus
 // proche du client. Les règles, dans l'ordre :
-//   1. le pro a coché la date dans son agenda et il est « disponible chantier » ;
+//   1. le pro a coché la date dans son agenda (c'est la SEULE déclaration de
+//      disponibilité : il n'existe plus de statut « indisponible ») ;
 //   2. il n'a pas déjà un chantier ce jour-là (un chantier par jour et par pro) ;
 //   3. il est à portée : distance code postal client ↔ code postal du pro ≤ son rayon ;
 //   4. le plus proche gagne — à égalité, celui qui a le moins de chantiers
@@ -10,6 +11,9 @@ import type { Pro } from "@prisma/client";
 import { prisma } from "./prisma";
 import { cpToLatLng, distanceKm } from "./geo";
 import { utcToParis } from "./dates";
+import { parseDates, parseDispo } from "./proStatus";
+
+export { parseDispo };
 
 export type Candidate = {
   pro: Pro;
@@ -18,34 +22,6 @@ export type Candidate = {
   eligible: boolean;
   raison: string;
 };
-
-/** {"2026-08-13":["10:00","17:00"], ...} — créneaux devis par jour d'un pro. */
-export function parseDispo(json: string): Record<string, string[]> {
-  try {
-    const obj = JSON.parse(json);
-    if (!obj || typeof obj !== "object" || Array.isArray(obj)) return {};
-    const out: Record<string, string[]> = {};
-    for (const [day, slots] of Object.entries(obj)) {
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(day) || !Array.isArray(slots)) continue;
-      const clean = (slots as unknown[]).filter(
-        (t): t is string => typeof t === "string" && /^\d{2}:\d{2}$/.test(t)
-      );
-      if (clean.length) out[day] = Array.from(new Set(clean)).sort();
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
-
-function parseDates(json: string): string[] {
-  try {
-    const arr = JSON.parse(json);
-    return Array.isArray(arr) ? arr.map(String) : [];
-  } catch {
-    return [];
-  }
-}
 
 /** Jour de Paris (AAAA-MM-JJ) d'un RDV. */
 export function bookingDay(startAt: Date): string {
@@ -106,9 +82,12 @@ async function chargeSemaine(day: string): Promise<Map<string, number>> {
   return map;
 }
 
-/** Pros « disponible chantier » ayant coché au moins un des jours demandés. */
+/**
+ * Tous les pros, avec les jours de chantier qu'ils ont cochés. Ne rien cocher
+ * = ne rien recevoir : c'est la seule façon de se déclarer indisponible.
+ */
 export async function prosChantier(): Promise<(Pro & { jours: string[] })[]> {
-  const pros = await prisma.pro.findMany({ where: { status: "disponible_chantier" } });
+  const pros = await prisma.pro.findMany();
   return pros.map((p) => Object.assign(p, { jours: parseDates(p.datesJson) }));
 }
 
@@ -219,8 +198,9 @@ export async function assignChantiers(
 // visite devis qui chevauche ce créneau (30 min par visite).
 // ---------------------------------------------------------------------------
 
+/** Tous les pros, avec les créneaux de visite qu'ils ont déclarés jour par jour. */
 export async function prosDevis(): Promise<(Pro & { dispo: Record<string, string[]> })[]> {
-  const pros = await prisma.pro.findMany({ where: { status: "disponible_devis" } });
+  const pros = await prisma.pro.findMany();
   return pros.map((p) => Object.assign(p, { dispo: parseDispo(p.devisDispoJson) }));
 }
 

--- a/app/src/lib/proAuth.ts
+++ b/app/src/lib/proAuth.ts
@@ -55,6 +55,9 @@ export function currentProId(): string | null {
 export const PRO_COOKIE_NAME = PRO_COOKIE;
 export const PRO_SESSION_MAX_AGE = SESSION_DAYS * 24 * 3600;
 
+// Valeurs acceptées pour Pro.status (simple mémoire de l'onglet ouvert dans
+// « Mes disponibilités »). Les deux dernières ne servent plus qu'aux comptes
+// créés avant la suppression du statut « indisponible ».
 export const PRO_STATUSES = [
   "disponible_devis",
   "disponible_chantier",

--- a/app/src/lib/proStatus.ts
+++ b/app/src/lib/proStatus.ts
@@ -1,34 +1,126 @@
-// Statuts de disponibilité d'un professionnel (client + admin).
-export const PRO_STATUS_META: Record<
-  string,
-  { label: string; dot: string; badge: string }
-> = {
-  disponible_devis: {
-    label: "Disponible pour un devis",
+// Disponibilité d'un professionnel : elle découle UNIQUEMENT de ce qu'il a
+// coché dans son agenda. Il n'y a plus de statut « indisponible » (décision du
+// client, 10 août) : ne rien déclarer suffit à ne rien recevoir. Les deux modes
+// ci-dessous ne servent qu'à choisir l'agenda qu'on remplit — ils ne bloquent
+// aucune attribution.
+
+export type ProMode = "devis" | "chantier";
+
+export const MODE_META: Record<ProMode, { label: string; court: string; dot: string; badge: string }> = {
+  devis: {
+    label: "Visites devis",
+    court: "Devis",
     dot: "#3b82f6", // 🔵 — même code couleur que les RDV devis
     badge: "bg-blue-100 text-blue-800",
   },
-  disponible_chantier: {
-    label: "Disponible pour un chantier",
+  chantier: {
+    label: "Chantiers",
+    court: "Chantiers",
     dot: "#22c55e", // 🟢 — même code couleur que les chantiers
     badge: "bg-green-100 text-green-800",
   },
-  sous_confirmation: {
-    label: "Disponible sous confirmation",
-    dot: "#f59e0b", // 🟠
-    badge: "bg-amber-100 text-amber-800",
-  },
-  indisponible: {
-    label: "Indisponible",
-    dot: "#ef4444", // 🔴
-    badge: "bg-red-100 text-red-700",
-  },
 };
 
-// « sous confirmation » a été retiré des choix (friction inutile — décision du
-// client) ; PRO_STATUS_META le garde pour afficher les anciens comptes.
-export const PRO_STATUS_ORDER = [
-  "disponible_devis",
-  "disponible_chantier",
-  "indisponible",
-];
+export const MODE_ORDER: ProMode[] = ["devis", "chantier"];
+
+// `Pro.status` ne sert plus qu'à retenir le dernier onglet ouvert par le pro
+// (les anciennes valeurs « indisponible » / « sous_confirmation » retombent
+// simplement sur l'agenda des chantiers).
+export function modeOf(status: string): ProMode {
+  return status === "disponible_devis" ? "devis" : "chantier";
+}
+
+export function statusOfMode(mode: ProMode): string {
+  return mode === "devis" ? "disponible_devis" : "disponible_chantier";
+}
+
+/** ["2026-08-12", …] — jours de chantier déclarés. */
+export function parseDates(json: string): string[] {
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr.filter((d): d is string => typeof d === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/** {"2026-08-13":["10:00","17:00"], …} — créneaux de visite déclarés par jour. */
+export function parseDispo(json: string): Record<string, string[]> {
+  try {
+    const obj = JSON.parse(json);
+    if (!obj || typeof obj !== "object" || Array.isArray(obj)) return {};
+    const out: Record<string, string[]> = {};
+    for (const [day, slots] of Object.entries(obj)) {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(day) || !Array.isArray(slots)) continue;
+      const clean = (slots as unknown[]).filter(
+        (t): t is string => typeof t === "string" && /^\d{2}:\d{2}$/.test(t)
+      );
+      if (clean.length) out[day] = Array.from(new Set(clean)).sort();
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+export type DispoResume = {
+  /** Jours de chantier à venir. */
+  jours: string[];
+  /** Jours comportant au moins un créneau de visite à venir. */
+  joursDevis: string[];
+  /** Nombre total de créneaux de visite à venir. */
+  creneaux: number;
+  /** Au moins une disponibilité déclarée à venir. */
+  actif: boolean;
+  label: string;
+  detail: string;
+  dot: string;
+  badge: string;
+};
+
+/**
+ * Ce que le professionnel a réellement déclaré à partir d'aujourd'hui — c'est
+ * ce que le gérant doit voir, à la place d'un statut déclaratif.
+ */
+export function dispoResume(
+  pro: { datesJson: string; devisDispoJson: string },
+  today: string
+): DispoResume {
+  const jours = parseDates(pro.datesJson)
+    .filter((d) => d >= today)
+    .sort();
+  const dispo = parseDispo(pro.devisDispoJson);
+  const joursDevis = Object.keys(dispo)
+    .filter((d) => d >= today)
+    .sort();
+  const creneaux = joursDevis.reduce((n, d) => n + dispo[d].length, 0);
+
+  const morceaux = [
+    jours.length ? `${jours.length} jour(s) de chantier` : "",
+    creneaux ? `${creneaux} créneau(x) de visite` : "",
+  ].filter(Boolean);
+
+  if (!jours.length && !creneaux) {
+    return {
+      jours,
+      joursDevis,
+      creneaux,
+      actif: false,
+      label: "Rien de déclaré",
+      detail: "Aucune disponibilité à venir",
+      dot: "#9ca3af", // gris
+      badge: "bg-gray-100 text-gray-600",
+    };
+  }
+  const mode: ProMode = jours.length ? "chantier" : "devis";
+  return {
+    jours,
+    joursDevis,
+    creneaux,
+    actif: true,
+    label: jours.length && creneaux ? "Chantiers + visites" : MODE_META[mode].label,
+    detail: morceaux.join(" · "),
+    dot: MODE_META[mode].dot,
+    badge: MODE_META[mode].badge,
+  };
+}


### PR DESCRIPTION
## Pourquoi

Cocher un jour implique déjà de ne pas être disponible le reste du temps : le bouton « Indisponible » faisait double emploi.

Conséquence importante : les deux statuts restants ne devaient pas continuer à bloquer les attributions. Sinon un pro qui bascule sur l'onglet « devis » perdrait la totalité de ses jours de chantier déclarés — exactement le piège que la demande visait à supprimer.

## Ce qui change

- `prosChantier()` / `prosDevis()` ne filtrent plus sur `Pro.status` : un pro reçoit du travail uniquement les jours et créneaux qu'il a cochés. Ne rien cocher = ne rien recevoir.
- Page **Mes disponibilités** : deux onglets (« Visites devis » / « Chantiers ») au lieu de trois statuts. `Pro.status` ne sert plus qu'à retenir le dernier onglet ouvert (aucune migration de schéma).
- Correction d'un défaut découvert au test : les enregistrements en attente sont désormais **fusionnés**. Cocher un jour puis changer d'onglet dans la même seconde faisait perdre le jour coché.
- Vues gérant : la liste des professionnels, l'agenda et le sélecteur de pro d'une fiche RDV affichent ce qui est **réellement déclaré** (« 3 jour(s) de chantier · 12 créneau(x) de visite ») au lieu d'un statut déclaratif. Le sélecteur signale « n'a pas déclaré ce jour ».
- Les APIs de planning envoient `devisDispoJson` : les créneaux de visite apparaissent enfin dans l'agenda (elles envoyaient encore l'ancien champ, vide depuis le passage aux créneaux jour par jour).

## Tests effectués (PostgreSQL local)

Jeu d'essai avec d'anciens statuts, pour vérifier qu'ils ne bloquent plus rien :

- Marc, statut `indisponible`, avec un jour de chantier et des créneaux déclarés → ses créneaux sont proposés aux clients, son jour de chantier aussi, et la réservation lui est attribuée
- Julien, onglet `devis` ouvert, avec un jour de chantier coché → le chantier lui est attribué (auparavant : jamais)
- Parcours navigateur : aucun bouton « Indisponible », deux onglets, repli sur l'agenda chantiers pour un ancien statut, onglet mémorisé après rechargement, jour coché juste avant une bascule bien conservé
- Vues gérant relues à l'écran (liste des pros, agenda semaine/mois, détail du jour)
- `npm run build` OK

## À noter

Un professionnel qui s'était mis « indisponible » **en laissant des dates cochées** redevient attribuable sur ces dates. Il lui suffit de décocher ce qu'il ne veut plus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_