### PR TITLE
Emails de confirmation aux clients + tableau de bord qui reste rapide

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -44,6 +44,11 @@ model Settings {
   notifyOwnerSms    Boolean  @default(false)
   ownerEmail        String   @default("")
   ownerPhone        String   @default("")
+  // Adresse expéditrice des emails (« Arboris Paysage <contact@arborispaysage.eu> »).
+  // Doit appartenir à un domaine vérifié chez Resend, sinon seuls les emails
+  // adressés au propriétaire du compte Resend partent. Vide = repli sur
+  // EMAIL_FROM, puis sur l'adresse d'essai de Resend.
+  emailFrom         String   @default("")
   // Ne proposer que les créneaux couverts par un pro disponible :
   // "off" = jamais, "chantier" = chantiers seulement, "tous" = devis + chantiers.
   // Sécurité : si aucun pro n'a déclaré la moindre disponibilité, le filtre est

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -25,7 +25,7 @@ type Booking = {
   status: string;
   proId: string | null;
   pro: { id: string; name: string } | null;
-  photos: Photo[];
+  photosCount: number;
 };
 type ProLite = {
   id: string;
@@ -99,9 +99,20 @@ export default function AdminDashboard() {
   const [notesDraft, setNotesDraft] = useState("");
   const [notesSaved, setNotesSaved] = useState(false);
   const [notesError, setNotesError] = useState("");
+  // Les photos ne sont plus dans la liste : on les charge à l'ouverture d'une
+  // fiche, sinon le tableau de bord téléchargerait toutes les images à chaque
+  // ouverture (des dizaines de Mo au bout de quelques mois).
+  const [photos, setPhotos] = useState<Record<string, Photo[]>>({});
+  const [photosLoading, setPhotosLoading] = useState<string | null>(null);
+  const [tronque, setTronque] = useState(false);
 
-  function load() {
-    fetch("/api/admin/bookings")
+  function load(opts?: { past?: boolean; q?: string }) {
+    const past = opts?.past ?? showPast;
+    const q = (opts?.q ?? search).trim();
+    const params = new URLSearchParams();
+    if (past) params.set("past", "1");
+    if (q) params.set("q", q);
+    fetch(`/api/admin/bookings?${params.toString()}`)
       .then((r) => {
         if (r.status === 401) {
           window.location.href = "/admin/login";
@@ -113,11 +124,20 @@ export default function AdminDashboard() {
         setBookings(data.bookings ?? []);
         setLeads(data.leads ?? []);
         setPros(data.pros ?? []);
+        setTronque(Boolean(data.tronque));
       })
       .finally(() => setLoading(false));
   }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(load, []);
+
+  // Recherche et historique : nouvelle requête (l'ancienne version filtrait
+  // une liste déjà entièrement téléchargée).
+  useEffect(() => {
+    const t = setTimeout(() => load({ past: showPast, q: search }), 350);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showPast, search]);
 
   function openCard(b: Booking) {
     const isOpen = expanded === b.id;
@@ -126,6 +146,20 @@ export default function AdminDashboard() {
       setNotesDraft(b.description);
       setNotesSaved(false);
       setNotesError("");
+      if (photos[b.id] === undefined) chargerPhotos(b.id);
+    }
+  }
+
+  async function chargerPhotos(id: string) {
+    setPhotosLoading(id);
+    try {
+      const res = await fetch(`/api/admin/bookings/${id}`);
+      const data = res.ok ? await res.json() : { photos: [] };
+      setPhotos((p) => ({ ...p, [id]: data.photos ?? [] }));
+    } catch {
+      setPhotos((p) => ({ ...p, [id]: [] }));
+    } finally {
+      setPhotosLoading(null);
     }
   }
 
@@ -170,7 +204,9 @@ export default function AdminDashboard() {
     });
     if (res.ok) {
       const data = await res.json();
-      setBookings((bs) => bs.map((b) => (b.id === id ? { ...b, photos: data.booking.photos } : b)));
+      const liste: Photo[] = data.booking.photos ?? [];
+      setPhotos((p) => ({ ...p, [id]: liste }));
+      setBookings((bs) => bs.map((b) => (b.id === id ? { ...b, photosCount: liste.length } : b)));
     }
   }
 
@@ -183,19 +219,9 @@ export default function AdminDashboard() {
     });
   }
 
-  const now = Date.now();
-  const q = search.trim().toLowerCase();
-  // Les devis « sans date » restent toujours visibles, en tête de liste.
-  // Les RDV annulés sont masqués sauf demande explicite.
-  const visible = bookings.filter((b) => {
-    if (!showCancelled && b.status === "annule") return false;
-    if (b.startAt && !showPast && new Date(b.startAt).getTime() < now - 24 * 3600_000) return false;
-    if (!q) return true;
-    return [b.firstName, b.lastName, b.phone, b.email, b.city, b.postalCode, b.address, b.description]
-      .join(" ")
-      .toLowerCase()
-      .includes(q);
-  });
+  // La fenêtre (à venir / historique) et la recherche sont faites par le
+  // serveur ; il ne reste ici que le masquage des RDV annulés.
+  const visible = bookings.filter((b) => showCancelled || b.status !== "annule");
   visible.sort((a, b) => {
     if (!a.startAt) return -1;
     if (!b.startAt) return 1;
@@ -211,6 +237,11 @@ export default function AdminDashboard() {
             <input type="checkbox" checked={showPast} onChange={(e) => setShowPast(e.target.checked)} />
             RDV passés
           </label>
+          {tronque && (
+            <span className="rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-800">
+              Liste limitée aux 200 plus proches — affinez la recherche
+            </span>
+          )}
           <label className="flex items-center gap-2 text-sm text-leaf-800/70">
             <input type="checkbox" checked={showCancelled} onChange={(e) => setShowCancelled(e.target.checked)} />
             Annulés
@@ -231,7 +262,11 @@ export default function AdminDashboard() {
       {loading && <p className="py-8 text-center text-leaf-800/60">Chargement…</p>}
       {!loading && visible.length === 0 && (
         <p className="card py-8 text-center text-leaf-800/60">
-          {q ? "Aucun rendez-vous ne correspond à cette recherche." : "Aucun rendez-vous pour le moment."}
+          {search.trim()
+            ? "Aucun rendez-vous ne correspond à cette recherche."
+            : showPast
+              ? "Aucun rendez-vous pour le moment."
+              : "Aucun rendez-vous à venir. Cochez « RDV passés » pour voir l'historique."}
         </p>
       )}
 
@@ -345,12 +380,18 @@ export default function AdminDashboard() {
                     </div>
                   </div>
 
-                  <PhotoUpload
-                    photos={b.photos.map((p) => p.dataUrl)}
-                    onChange={(urls) => savePhotos(b.id, urls)}
-                    label="Photos (10 max)"
-                    maxPhotos={10}
-                  />
+                  {photosLoading === b.id && photos[b.id] === undefined ? (
+                    <p className="rounded-xl bg-sand-50 px-3 py-2 text-sm text-leaf-800/60">
+                      Chargement des {b.photosCount} photo(s)…
+                    </p>
+                  ) : (
+                    <PhotoUpload
+                      photos={(photos[b.id] ?? []).map((p) => p.dataUrl)}
+                      onChange={(urls) => savePhotos(b.id, urls)}
+                      label="Photos (10 max)"
+                      maxPhotos={10}
+                    />
+                  )}
                   <div>
                     <span className="label">Statut</span>
                     <div className="flex flex-wrap gap-2">

--- a/app/src/app/admin/parametres/page.tsx
+++ b/app/src/app/admin/parametres/page.tsx
@@ -40,6 +40,9 @@ type SettingsView = {
   notifyOwnerSms: boolean;
   ownerEmail: string;
   ownerPhone: string;
+  emailFrom: string;
+  emailConfigured: boolean;
+  emailClientsOk: boolean;
   proFilterMode: string;
   smsConfirmation: string;
   smsReminder24h: string;
@@ -64,6 +67,12 @@ export default function AdminSettingsPage() {
   const [testMsg, setTestMsg] = useState("");
   const [testOk, setTestOk] = useState(false);
   const [testing, setTesting] = useState(false);
+  // Test d'envoi vers une adresse quelconque : le seul moyen de vérifier que
+  // les confirmations partent vraiment aux clients.
+  const [testClientTo, setTestClientTo] = useState("");
+  const [testClientMsg, setTestClientMsg] = useState("");
+  const [testClientOk, setTestClientOk] = useState(false);
+  const [testingClient, setTestingClient] = useState(false);
   const [gallery, setGallery] = useState<string[]>([]);
   const [gallerySaved, setGallerySaved] = useState(false);
   const logoInputRef = useRef<HTMLInputElement>(null);
@@ -153,6 +162,7 @@ export default function AdminSettingsPage() {
         notifyOwnerEmail: s.notifyOwnerEmail,
         notifyOwnerSms: s.notifyOwnerSms,
         ownerEmail: s.ownerEmail,
+        emailFrom: s.emailFrom,
         ownerPhone: s.ownerPhone,
         proFilterMode: s.proFilterMode,
         smsConfirmation: s.smsConfirmation,
@@ -179,6 +189,23 @@ export default function AdminSettingsPage() {
     setTesting(false);
     setTestOk(Boolean(data.ok));
     setTestMsg(data.message ?? data.error ?? "Test impossible.");
+  }
+
+  // Test « côté client » : on écrit à une adresse choisie, comme le ferait une
+  // confirmation de rendez-vous.
+  async function testerEmailClient() {
+    setTestingClient(true);
+    setTestClientMsg("");
+    await save();
+    const res = await fetch("/api/admin/test-email", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ to: testClientTo.trim() }),
+    });
+    const data = await res.json();
+    setTestingClient(false);
+    setTestClientOk(Boolean(data.ok));
+    setTestClientMsg(data.message ?? data.error ?? "Test impossible.");
   }
 
   return (
@@ -497,6 +524,81 @@ export default function AdminSettingsPage() {
                 }`}
               >
                 {testMsg}
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* Emails envoyés aux clients */}
+        <section className="card space-y-3">
+          <h2 className="font-bold">Emails envoyés à vos clients</h2>
+          <p
+            className={`rounded-xl px-3 py-2 text-sm ${
+              s.emailClientsOk ? "bg-leaf-50 text-leaf-800" : "bg-amber-50 text-amber-900"
+            }`}
+          >
+            {!s.emailConfigured ? (
+              <>
+                <b>Aucun email ne part pour l&apos;instant.</b> La clé Resend n&apos;est pas active
+                sur le site.
+              </>
+            ) : s.emailClientsOk ? (
+              <>
+                <b>✓ Vos clients reçoivent bien leur confirmation</b>, envoyée depuis{" "}
+                <b>{s.emailFrom}</b>. Vérifiez-le de temps en temps avec le bouton de test
+                ci-dessous.
+              </>
+            ) : (
+              <>
+                <b>Vos clients ne reçoivent PAS leur confirmation.</b> Sans adresse d&apos;expédition
+                à vous, Resend n&apos;écrit qu&apos;au propriétaire du compte — donc à vous seul.
+                Marche à suivre : vérifiez votre nom de domaine dans Resend (il vous donne des lignes
+                à recopier chez OVH), puis indiquez ci-dessous l&apos;adresse d&apos;expédition.
+              </>
+            )}
+          </p>
+          <div>
+            <span className="label">Adresse qui apparaît comme expéditeur</span>
+            <input
+              className="input"
+              placeholder="Arboris Paysage <contact@arborispaysage.eu>"
+              value={s.emailFrom}
+              onChange={(e) => set({ emailFrom: e.target.value })}
+            />
+            <p className="mt-1 text-xs text-leaf-800/60">
+              Le domaine de cette adresse doit être vérifié dans Resend. Laissez vide tant que ce
+              n&apos;est pas fait : les alertes continueront de vous parvenir.
+            </p>
+          </div>
+          <div className="border-t border-leaf-100 pt-3">
+            <span className="label">Vérifier qu&apos;un client reçoit bien l&apos;email</span>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <input
+                className="input flex-1"
+                type="email"
+                placeholder="Une autre adresse à vous (Gmail, Orange…)"
+                value={testClientTo}
+                onChange={(e) => setTestClientTo(e.target.value)}
+              />
+              <button
+                className="btn-secondary whitespace-nowrap"
+                onClick={testerEmailClient}
+                disabled={testingClient || !testClientTo.trim()}
+              >
+                {testingClient ? "Envoi en cours…" : "Envoyer un test"}
+              </button>
+            </div>
+            <p className="mt-1 text-xs text-leaf-800/60">
+              Utilisez une adresse <b>différente</b> de celle de votre compte Resend : c&apos;est la
+              seule façon de prouver que vos clients reçoivent vraiment leurs confirmations.
+            </p>
+            {testClientMsg && (
+              <p
+                className={`mt-2 rounded-xl px-3 py-2 text-sm ${
+                  testClientOk ? "bg-leaf-50 text-leaf-800" : "bg-red-50 text-red-700"
+                }`}
+              >
+                {testClientMsg}
               </p>
             )}
           </div>

--- a/app/src/app/api/admin/bookings/[id]/route.ts
+++ b/app/src/app/api/admin/bookings/[id]/route.ts
@@ -8,6 +8,21 @@ export const dynamic = "force-dynamic";
 
 const STATUSES = ["a_faire", "devis_envoye", "gagne", "perdu", "annule"];
 
+/**
+ * GET /api/admin/bookings/:id — les photos d'un RDV, chargées seulement à
+ * l'ouverture de la fiche (elles sont trop lourdes pour la liste).
+ */
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const photos = await prisma.photo.findMany({
+    where: { bookingId: params.id },
+    select: { id: true, dataUrl: true },
+  });
+  return NextResponse.json({ photos });
+}
+
 // PATCH /api/admin/bookings/:id { status?, description?, photos? } —
 // statut, notes ou photos (fiche du devis) mis à jour par le gérant.
 export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {

--- a/app/src/app/api/admin/bookings/route.ts
+++ b/app/src/app/api/admin/bookings/route.ts
@@ -6,20 +6,65 @@ import { parisTimeToUtc } from "@/lib/dates";
 
 export const dynamic = "force-dynamic";
 
-// GET /api/admin/bookings — liste des RDV (photos incluses) pour le tableau de bord.
-export async function GET() {
+// Au-delà, on ne charge pas tout : le tableau de bord doit rester rapide même
+// après des centaines de rendez-vous.
+const MAX_RESULTATS = 200;
+
+/**
+ * GET /api/admin/bookings?past=1&q=… — liste des RDV du tableau de bord.
+ *
+ * Les photos ne sont JAMAIS renvoyées ici (ce sont des images en base64, très
+ * lourdes) : seul leur nombre l'est, et la fiche les charge à son ouverture.
+ * Par défaut on ne renvoie que les RDV utiles au quotidien (à venir, plus les
+ * devis sans date) ; `past=1` remonte l'historique et `q` cherche dans tout.
+ */
+export async function GET(req: NextRequest) {
   if (!isAdminAuthenticated()) {
     return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
   }
-  const bookings = await prisma.booking.findMany({
-    orderBy: { startAt: "asc" },
-    include: {
-      photos: { select: { id: true, dataUrl: true } },
-      pro: { select: { id: true, name: true } },
-    },
-  });
+  const past = req.nextUrl.searchParams.get("past") === "1";
+  const q = (req.nextUrl.searchParams.get("q") ?? "").trim();
+  const depuis = new Date(Date.now() - 24 * 3600_000);
+
+  // Recherche ou historique demandé → on ouvre la fenêtre à tout l'historique.
+  const fenetre =
+    past || q
+      ? {}
+      : { OR: [{ startAt: { gte: depuis } }, { startAt: null }] };
+
+  const recherche = q
+    ? {
+        OR: [
+          { firstName: { contains: q, mode: "insensitive" as const } },
+          { lastName: { contains: q, mode: "insensitive" as const } },
+          { phone: { contains: q, mode: "insensitive" as const } },
+          { email: { contains: q, mode: "insensitive" as const } },
+          { city: { contains: q, mode: "insensitive" as const } },
+          { postalCode: { contains: q, mode: "insensitive" as const } },
+          { address: { contains: q, mode: "insensitive" as const } },
+          { description: { contains: q, mode: "insensitive" as const } },
+        ],
+      }
+    : {};
+
+  const where = { AND: [fenetre, recherche] };
+
+  const [bookings, total] = await Promise.all([
+    prisma.booking.findMany({
+      where,
+      orderBy: { startAt: "asc" },
+      take: MAX_RESULTATS,
+      include: {
+        // Le nombre de photos suffit à la liste ; les images arrivent au clic.
+        _count: { select: { photos: true } },
+        pro: { select: { id: true, name: true } },
+      },
+    }),
+    prisma.booking.count({ where }),
+  ]);
+
   const pros = await prisma.pro.findMany({
-    select: { id: true, name: true, basePostalCode: true, radiusKm: true, status: true },
+    select: { id: true, name: true, basePostalCode: true, radiusKm: true, datesJson: true },
     orderBy: { name: "asc" },
   });
   // Les prospects venus des publicités ont leur propre section (Publicités Meta).
@@ -28,7 +73,13 @@ export async function GET() {
     orderBy: { createdAt: "desc" },
     take: 50,
   });
-  return NextResponse.json({ bookings, leads, pros });
+  return NextResponse.json({
+    bookings: bookings.map(({ _count, ...b }) => ({ ...b, photosCount: _count.photos })),
+    leads,
+    pros,
+    total,
+    tronque: total > bookings.length,
+  });
 }
 
 /** Photos valides : data URLs image, 10 max. */

--- a/app/src/app/api/admin/settings/route.ts
+++ b/app/src/app/api/admin/settings/route.ts
@@ -4,6 +4,7 @@ import { isAdminAuthenticated } from "@/lib/auth";
 import { getSettings } from "@/lib/settings";
 import { geocode } from "@/lib/zone";
 import { googleConfigured } from "@/lib/google";
+import { emailConfigured, usingTestSender } from "@/lib/email";
 
 export const dynamic = "force-dynamic";
 
@@ -14,6 +15,10 @@ function sanitize(settings: Awaited<ReturnType<typeof getSettings>>) {
     ...rest,
     googleConnected: Boolean(googleRefreshToken),
     googleConfigured: googleConfigured(),
+    // Diagnostic des emails clients : la clé est-elle là, et un expéditeur
+    // vérifié est-il renseigné ? Sans lui, seul le gérant reçoit ses alertes.
+    emailConfigured: emailConfigured(),
+    emailClientsOk: emailConfigured() && !usingTestSender(settings.emailFrom),
   };
 }
 
@@ -75,6 +80,7 @@ export async function PUT(req: NextRequest) {
     notifyOwnerSms: typeof body.notifyOwnerSms === "boolean" ? body.notifyOwnerSms : undefined,
     ownerEmail: str("ownerEmail"),
     ownerPhone: str("ownerPhone"),
+    emailFrom: str("emailFrom"),
     proFilterMode: ["off", "chantier", "tous"].includes(str("proFilterMode") ?? "")
       ? str("proFilterMode")
       : undefined,

--- a/app/src/app/api/admin/test-email/route.ts
+++ b/app/src/app/api/admin/test-email/route.ts
@@ -1,21 +1,36 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { isAdminAuthenticated } from "@/lib/auth";
 import { getSettings } from "@/lib/settings";
-import { emailConfigured, sendEmailChecked } from "@/lib/email";
-import { ownerEmailOf } from "@/lib/notifications";
+import { emailConfigured, sendEmailChecked, usingTestSender } from "@/lib/email";
+import { ownerEmailOf, expediteurOf } from "@/lib/notifications";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
 
-// POST /api/admin/test-email — envoie une alerte d'essai au gérant et renvoie
-// un diagnostic lisible : c'est l'outil d'auto-dépannage de la section Alertes.
-export async function POST() {
+/**
+ * POST /api/admin/test-email { to? } — envoie un email d'essai et renvoie un
+ * diagnostic lisible : c'est l'outil d'auto-dépannage de la section Alertes.
+ * Sans `to`, on teste l'alerte au gérant ; avec `to`, on teste l'envoi à un
+ * client (le seul moyen de vérifier qu'un domaine vérifié fonctionne).
+ */
+export async function POST(req: NextRequest) {
   if (!isAdminAuthenticated()) {
     return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
   }
+  let body: { to?: string } = {};
+  try {
+    body = await req.json();
+  } catch {
+    // corps vide = test de l'alerte gérant
+  }
   const settings = await getSettings();
-  const to = ownerEmailOf(settings);
+  const demande = String(body.to ?? "").trim();
+  const versClient = demande.length > 0;
+  const to = versClient ? demande : ownerEmailOf(settings);
 
+  if (versClient && !/^[^@\s]+@[^@\s]+\.[^@\s]+$/.test(to)) {
+    return NextResponse.json({ ok: false, message: "Cette adresse email n'est pas valide." });
+  }
   if (!to) {
     return NextResponse.json({
       ok: false,
@@ -28,9 +43,7 @@ export async function POST() {
     // frappe ou une valeur vide, sans jamais divulguer la clé elle-même.
     const noms = Object.keys(process.env).filter((k) => /resend/i.test(k));
     const detail = noms.length
-      ? noms
-          .map((n) => `« ${n} » (${(process.env[n] ?? "").trim().length} caractères)`)
-          .join(", ")
+      ? noms.map((n) => `« ${n} » (${(process.env[n] ?? "").trim().length} caractères)`).join(", ")
       : "aucune";
     return NextResponse.json({
       ok: false,
@@ -42,23 +55,43 @@ export async function POST() {
     });
   }
 
+  const expediteur = expediteurOf(settings);
   const res = await sendEmailChecked({
     to,
-    subject: `Test d'alerte — ${settings.companyName}`,
-    text: [
-      "Ceci est un email de test envoyé depuis vos paramètres.",
-      "",
-      "Si vous le recevez, vos alertes de nouvelle réservation et de nouveau prospect fonctionnent.",
-      "",
-      settings.companyName,
-    ].join("\n"),
+    from: expediteur,
+    subject: versClient
+      ? `Test d'email client — ${settings.companyName}`
+      : `Test d'alerte — ${settings.companyName}`,
+    text: versClient
+      ? [
+          "Ceci est un email de test envoyé depuis votre espace gérant.",
+          "",
+          "Si vous le recevez à cette adresse, les confirmations de rendez-vous",
+          "partent bien à vos clients.",
+          "",
+          settings.companyName,
+        ].join("\n")
+      : [
+          "Ceci est un email de test envoyé depuis vos paramètres.",
+          "",
+          "Si vous le recevez, vos alertes de nouvelle réservation et de nouveau prospect fonctionnent.",
+          "",
+          settings.companyName,
+        ].join("\n"),
   });
 
   if (res.ok) {
+    // Réussir vers sa propre adresse ne prouve rien : avec l'expéditeur d'essai
+    // de Resend, seul le propriétaire du compte reçoit quoi que ce soit.
+    const fragile = usingTestSender(expediteur);
     return NextResponse.json({
       ok: true,
       to,
-      message: `Email de test envoyé à ${to}. Vérifiez votre boîte (et les indésirables la première fois).`,
+      message:
+        `Email de test envoyé à ${to}. Vérifiez la boîte (et les indésirables la première fois).` +
+        (fragile
+          ? " Attention : aucun expéditeur n'est configuré, l'adresse d'essai de Resend est utilisée — elle n'écrit qu'au propriétaire du compte Resend. Vos clients, eux, ne recevront rien tant qu'un domaine vérifié ne sera pas renseigné ci-dessus."
+          : ""),
     });
   }
 
@@ -66,13 +99,20 @@ export async function POST() {
   const brut = res.error ?? "";
   let message = `L'envoi a été refusé : ${brut}`;
   if (/only send testing emails to your own email/i.test(brut)) {
-    message = `Resend refuse d'écrire à ${to} : sans nom de domaine vérifié, il n'autorise que l'adresse propriétaire du compte Resend. Mettez cette adresse-là, ou vérifiez un domaine dans Resend.`;
+    message =
+      `Resend refuse d'écrire à ${to} : sans domaine vérifié, il n'autorise que l'adresse propriétaire du compte Resend. ` +
+      "C'est exactement ce qui empêche vos clients de recevoir leur confirmation. " +
+      "Vérifiez votre domaine dans Resend, puis indiquez l'expéditeur ci-dessus (ex. contact@votre-domaine.fr).";
   } else if (/api key is invalid|unauthorized|401/i.test(brut)) {
     message =
       "La clé Resend est refusée (invalide ou révoquée). Recréez-en une dans Resend, puis remplacez RESEND_API_KEY dans Vercel et redéployez.";
-  } else if (/domain is not verified/i.test(brut)) {
+  } else if (/domain is not verified|not verified/i.test(brut)) {
     message =
-      "Le domaine d'expédition n'est pas vérifié dans Resend. Retirez la variable EMAIL_FROM de Vercel pour utiliser l'adresse d'essai de Resend, ou vérifiez votre domaine.";
+      `Le domaine de l'expéditeur « ${expediteur || "(non renseigné)"} » n'est pas vérifié dans Resend. ` +
+      "Terminez la vérification du domaine dans Resend (ajout des enregistrements DNS chez OVH), ou videz le champ expéditeur pour repasser à l'adresse d'essai.";
+  } else if (/from.*invalid|invalid.*from/i.test(brut)) {
+    message =
+      `L'expéditeur « ${expediteur} » n'est pas accepté. Utilisez la forme « Nom <adresse@domaine.fr> » avec un domaine vérifié dans Resend.`;
   }
   return NextResponse.json({ ok: false, to, message });
 }

--- a/app/src/app/api/bookings/route.ts
+++ b/app/src/app/api/bookings/route.ts
@@ -162,8 +162,8 @@ export async function POST(req: NextRequest) {
           (nonAttribues ? ` (+ ${nonAttribues} jour(s) à attribuer)` : "");
 
     // SMS + email de confirmation (dates groupées si plusieurs jours) + alerte gérant
-    await sendConfirmation(primary, settings, days);
-    await notifyOwnerNewBooking(primary, settings, days, proLabel);
+    const confirmation = await sendConfirmation(primary, settings, days);
+    await notifyOwnerNewBooking(primary, settings, days, proLabel, confirmation);
     return NextResponse.json({ id: primary.id }, { status: 201 });
   }
 
@@ -193,9 +193,16 @@ export async function POST(req: NextRequest) {
   if (proVisite) await notifyProNewDevis(proVisite, booking, settings);
 
   // 5. SMS de confirmation immédiat + email avec .ics — sans action du gérant.
-  await sendConfirmation(booking, settings);
-  // 6. Alerte au gérant : plus besoin d'ouvrir le tableau de bord.
-  await notifyOwnerNewBooking(booking, settings, undefined, proVisite ? proVisite.name : undefined);
+  const confirmation = await sendConfirmation(booking, settings);
+  // 6. Alerte au gérant : plus besoin d'ouvrir le tableau de bord. Elle signale
+  //    aussi l'échec éventuel de la confirmation au client.
+  await notifyOwnerNewBooking(
+    booking,
+    settings,
+    undefined,
+    proVisite ? proVisite.name : undefined,
+    confirmation
+  );
 
   return NextResponse.json({ id: booking.id }, { status: 201 });
 }

--- a/app/src/lib/email.ts
+++ b/app/src/lib/email.ts
@@ -10,7 +10,17 @@ export type EmailOptions = {
   subject: string;
   text: string;
   icsContent?: string;
+  /** Expéditeur (réglable depuis l'admin). Vide = EMAIL_FROM, puis adresse d'essai Resend. */
+  from?: string;
 };
+
+/** Adresse d'essai de Resend : n'écrit qu'au propriétaire du compte. */
+export const EXPEDITEUR_ESSAI = "RDV <onboarding@resend.dev>";
+
+/** Vrai tant qu'aucun domaine vérifié n'est configuré (emails clients bloqués). */
+export function usingTestSender(settingsFrom?: string): boolean {
+  return !(settingsFrom?.trim() || process.env.EMAIL_FROM || "").trim();
+}
 
 export async function sendEmail(options: EmailOptions): Promise<boolean> {
   return (await sendEmailChecked(options)).ok;
@@ -26,7 +36,7 @@ export async function sendEmailChecked(
   }
   try {
     const body: Record<string, unknown> = {
-      from: process.env.EMAIL_FROM || "RDV <onboarding@resend.dev>",
+      from: options.from?.trim() || process.env.EMAIL_FROM || EXPEDITEUR_ESSAI,
       to: [options.to],
       subject: options.subject,
       text: options.text,

--- a/app/src/lib/notifications.ts
+++ b/app/src/lib/notifications.ts
@@ -1,7 +1,7 @@
 // Orchestration des notifications liées à un RDV.
 import type { Booking, Pro, Settings } from "@prisma/client";
 import { sendSms } from "./sms";
-import { sendEmail } from "./email";
+import { sendEmail, sendEmailChecked } from "./email";
 import { buildIcs } from "./ics";
 import { renderTemplate } from "./templates";
 import { formatDateFr, formatTimeFr } from "./dates";
@@ -17,6 +17,11 @@ export function ownerEmailOf(settings: Settings): string {
 
 export function ownerPhoneOf(settings: Settings): string {
   return settings.ownerPhone || settings.companyPhone || "";
+}
+
+/** Expéditeur des emails : réglage de l'admin, sinon variable d'environnement. */
+export function expediteurOf(settings: Settings): string {
+  return settings.emailFrom.trim();
 }
 
 const PROJECT_LABELS: Record<string, string> = {
@@ -45,7 +50,8 @@ export async function notifyOwnerNewBooking(
   booking: Booking,
   settings: Settings,
   groupDates?: Date[],
-  proLabel?: string
+  proLabel?: string,
+  confirmation?: ConfirmationResult
 ): Promise<void> {
   const quand = whenLabel(booking, groupDates);
   const type = booking.kind === "chantier" ? "chantier" : "devis";
@@ -61,6 +67,7 @@ export async function notifyOwnerNewBooking(
       tasks.push(
         sendEmail({
           to,
+          from: expediteurOf(settings),
           subject: `Nouveau RDV ${type} — ${client} (${quand})`,
           text: [
             `Nouvelle réservation sur votre site :`,
@@ -75,6 +82,11 @@ export async function notifyOwnerNewBooking(
             proLabel ? `Attribué à : ${proLabel}` : "",
             booking.description ? `Message    : ${booking.description}` : "",
             ``,
+            // Le client croit avoir reçu une confirmation : si elle n'est pas
+            // partie, il faut le savoir tout de suite pour le rappeler.
+            confirmation && !confirmation.emailOk
+              ? `/!\\ L'EMAIL DE CONFIRMATION AU CLIENT N'EST PAS PARTI (${confirmation.emailError ?? "motif inconnu"}).\n    Pensez à le contacter. Réglage : Paramètres > Emails envoyés aux clients.\n`
+              : "",
             `Retrouvez ce rendez-vous dans votre tableau de bord.`,
           ]
             .filter(Boolean)
@@ -127,6 +139,7 @@ export async function notifyProNewChantier(
     .join(", ");
   await sendEmail({
     to: pro.email,
+    from: expediteurOf(settings),
     subject: `Nouveau chantier : ${joursFr(days)} — ${booking.city || booking.postalCode}`,
     text: [
       `Bonjour ${pro.name},`,
@@ -165,6 +178,7 @@ export async function notifyProNewDevis(
   const quand = `${formatDateFr(booking.startAt)} à ${formatTimeFr(booking.startAt)}`;
   await sendEmail({
     to: pro.email,
+    from: expediteurOf(settings),
     subject: `Nouvelle visite devis : ${quand} — ${booking.city || booking.postalCode}`,
     text: [
       `Bonjour ${pro.name},`,
@@ -202,6 +216,7 @@ export async function notifyOwnerReassign(
   const quand = whenLabel(booking);
   await sendEmail({
     to,
+    from: expediteurOf(settings),
     subject: nouveau
       ? `${booking.kind === "devis" ? "Visite devis réattribuée" : "Chantier réattribué"} : ${quand}`
       : `${booking.kind === "devis" ? "Visite devis SANS professionnel" : "Chantier SANS professionnel"} : ${quand}`,
@@ -218,25 +233,34 @@ export async function notifyOwnerReassign(
   });
 }
 
+/** Résultat de la confirmation au client, pour pouvoir alerter le gérant. */
+export type ConfirmationResult = { emailOk: boolean; emailError?: string };
+
 /** SMS + email de confirmation, envoyés immédiatement après la réservation.
- *  `groupDates` : chantier multi-jours ({{date}} devient « du … au … »). */
+ *  `groupDates` : chantier multi-jours ({{date}} devient « du … au … »).
+ *  Renvoie l'issue de l'email : tant qu'aucun domaine n'est vérifié chez
+ *  Resend, il est refusé et le gérant doit le savoir. */
 export async function sendConfirmation(
   booking: Booking,
   settings: Settings,
   groupDates?: Date[]
-): Promise<void> {
+): Promise<ConfirmationResult> {
   const smsBody = renderTemplate(settings.smsConfirmation, booking, settings, groupDates);
   const emailSubject = renderTemplate(settings.emailSubject, booking, settings, groupDates);
   const emailBody = renderTemplate(settings.emailBody, booking, settings, groupDates);
-  await Promise.allSettled([
-    sendSms(booking.phone, smsBody),
-    sendEmail({
-      to: booking.email,
-      subject: emailSubject,
-      text: emailBody,
-      icsContent: buildIcs(booking, settings),
-    }),
+  const [, email] = await Promise.all([
+    sendSms(booking.phone, smsBody).catch(() => false),
+    booking.email
+      ? sendEmailChecked({
+          to: booking.email,
+          from: expediteurOf(settings),
+          subject: emailSubject,
+          text: emailBody,
+          icsContent: buildIcs(booking, settings),
+        }).catch((e) => ({ ok: false, error: String(e) }))
+      : Promise.resolve({ ok: false, error: "aucune adresse email" }),
   ]);
+  return { emailOk: email.ok, emailError: email.ok ? undefined : email.error };
 }
 
 /**
@@ -266,6 +290,7 @@ export async function notifyOwnerNewLead(
       tasks.push(
         sendEmail({
           to,
+          from: expediteurOf(settings),
           subject: `Nouveau prospect — ${lead.name}${lead.postalCode ? ` (${lead.postalCode})` : ""}`,
           text: [
             `Nouveau prospect à rappeler (${origine}) :`,


### PR DESCRIPTION
## 1. Emails de confirmation aux clients

Le blocage restant est la vérification du domaine chez Resend, que seul le client peut faire. Ce qui est livré ici, c'est tout ce qui rend cette bascule possible et vérifiable sans toucher au code.

- **Adresse d'expédition réglable depuis l'admin** (`Settings.emailFrom`) : plus besoin d'éditer une variable d'environnement dans Vercel pour passer au domaine vérifié.
- **Nouvelle section « Emails envoyés à vos clients »** dans les paramètres, qui dit franchement lequel des trois états s'applique :
  - pas de clé Resend → « Aucun email ne part pour l'instant »
  - clé présente, pas d'expéditeur → « Vos clients ne reçoivent PAS leur confirmation », avec la marche à suivre
  - expéditeur renseigné → « ✓ Vos clients reçoivent bien leur confirmation »
- **Test vers une adresse au choix** : envoyer un test au propriétaire du compte Resend réussit toujours, même quand les clients ne reçoivent rien. Pouvoir viser une autre adresse est le seul moyen de le prouver.
- **`sendConfirmation` renvoie son résultat** et l'alerte de nouvelle réservation prévient le gérant quand la confirmation du client n'est pas partie, avec le motif : il peut rappeler le client au lieu de le laisser sans nouvelle.
- Motifs de refus Resend traduits en français, dont le cas « domaine non vérifié ».

## 2. Tableau de bord

Le tableau de bord téléchargeait **tous** les rendez-vous depuis le début, **avec toutes les photos** (des images en base64 dans la base).

- Les photos sortent de la liste : seul leur nombre y figure, les images se chargent à l'ouverture d'une fiche (`GET /api/admin/bookings/:id`).
- Fenêtre côté serveur : par défaut les RDV à venir et les devis sans date, l'historique à la demande, plafonné à 200 résultats avec un bandeau quand c'est tronqué.
- **La recherche passe côté serveur** : elle couvre donc tout l'historique, alors qu'elle se limitait auparavant à ce qui était déjà chargé.

Mesure sur 250 rendez-vous et 252 photos (~180 Ko chacune) :

| | Avant | Après |
| --- | --- | --- |
| Ouverture du tableau de bord | **43,4 Mo** | **81 Ko** |
| Ouverture d'une fiche avec 3 photos | (déjà chargées) | 528 Ko, à la demande |

## 3. Correction au passage

Le sélecteur « Professionnel attribué » d'une fiche lisait `datesJson`, que l'API ne renvoyait pas : **tous** les pros étaient affichés comme « n'a pas déclaré ce jour ». Régression introduite par la PR #44, corrigée ici.

## Tests effectués

- Base PostgreSQL locale chargée à 250 RDV / 252 photos ; mesures ci-dessus relevées via l'API et via le navigateur.
- Recherche serveur vérifiée sur un rendez-vous **passé**, retrouvé par ses notes, par la ville et par le nom.
- Chargement des photos à l'ouverture d'une fiche vérifié au navigateur (3 photos affichées), et `401` sans session.
- Les trois états de la section emails vérifiés au navigateur (sans clé, clé sans expéditeur, clé + expéditeur), enregistrement de l'expéditeur conservé après rechargement, adresse invalide refusée.
- Alerte gérant testée dans les deux cas : le texte d'avertissement apparaît quand la confirmation client échoue, et pas quand elle réussit.
- `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_