### PR TITLE
Phase 0 — Secteurs d'intervention : débloquer Bordeaux

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -82,6 +82,32 @@ model Settings {
   updatedAt         DateTime @updatedAt
 }
 
+// Secteur d'exploitation (Bordeaux, Béziers…). Sert à trois choses :
+//   1. la zone d'intervention — un client est couvert si AU MOINS UNE agence
+//      le couvre (préfixe de code postal OU rayon autour de l'agence) ;
+//   2. le regroupement des paysagistes pour les agendas d'équipe ;
+//   3. le filtrage des vues du gérant.
+// Tant qu'aucune agence n'existe, l'application retombe sur la zone unique
+// historique décrite dans Settings — rien ne casse pour l'existant.
+model Agence {
+  id              String   @id @default(cuid())
+  createdAt       DateTime @default(now())
+  nom             String
+  // Couleur d'identification dans les agendas
+  couleur         String   @default("#347030")
+  address         String   @default("")
+  postalCode      String   @default("")
+  city            String   @default("")
+  lat             Float?
+  lng             Float?
+  radiusKm        Int      @default(30)
+  // Préfixes ou codes postaux couverts : ["33","40"] — "33" couvre toute la Gironde
+  postalCodesJson String   @default("[]")
+  actif           Boolean  @default(true)
+  ordre           Int      @default(0)
+  pros            Pro[]
+}
+
 model Booking {
   id             String    @id @default(cuid())
   createdAt      DateTime  @default(now())
@@ -151,6 +177,9 @@ model Pro {
   baseCity       String   @default("")
   basePostalCode String   @default("")
   radiusKm       Int      @default(30)
+  // Secteur de rattachement (agenda d'équipe). Null = non rattaché.
+  agenceId       String?
+  agence         Agence?  @relation(fields: [agenceId], references: [id], onDelete: SetNull)
   // Dernier onglet ouvert dans « Mes disponibilités » (disponible_devis |
   // disponible_chantier). N'a plus d'effet sur les attributions : la
   // disponibilité découle uniquement de datesJson / devisDispoJson.

--- a/app/src/app/admin/parametres/AgencesSection.tsx
+++ b/app/src/app/admin/parametres/AgencesSection.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+// Secteurs d'exploitation (Bordeaux, Béziers…). Dès qu'un secteur existe, c'est
+// lui qui définit la zone d'intervention : un client est accepté s'il est
+// couvert par AU MOINS UN secteur. C'est ce qui permet d'exploiter deux villes
+// éloignées sans que l'une exclue l'autre.
+import { useEffect, useState } from "react";
+
+type Agence = {
+  id: string;
+  nom: string;
+  couleur: string;
+  address: string;
+  postalCode: string;
+  city: string;
+  radiusKm: number;
+  postalCodesJson: string;
+  actif: boolean;
+  prosCount: number;
+};
+
+const COULEURS = ["#347030", "#2563eb", "#b45309", "#7c3aed", "#be123c", "#0f766e"];
+
+function codesDe(json: string): string {
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr.join(", ") : "";
+  } catch {
+    return "";
+  }
+}
+
+export default function AgencesSection() {
+  const [agences, setAgences] = useState<Agence[]>([]);
+  const [chargement, setChargement] = useState(true);
+  const [erreur, setErreur] = useState("");
+  const [nouveau, setNouveau] = useState(false);
+  const [brouillon, setBrouillon] = useState({
+    nom: "",
+    postalCode: "",
+    city: "",
+    address: "",
+    radiusKm: 30,
+    postalCodes: "",
+    couleur: COULEURS[0],
+  });
+
+  function charger() {
+    fetch("/api/admin/agences")
+      .then((r) => (r.ok ? r.json() : { agences: [] }))
+      .then((d) => setAgences(d.agences ?? []))
+      .finally(() => setChargement(false));
+  }
+  useEffect(charger, []);
+
+  async function creer() {
+    setErreur("");
+    const res = await fetch("/api/admin/agences", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(brouillon),
+    });
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}));
+      setErreur(d.error ?? "Création impossible.");
+      return;
+    }
+    setNouveau(false);
+    setBrouillon({
+      nom: "",
+      postalCode: "",
+      city: "",
+      address: "",
+      radiusKm: 30,
+      postalCodes: "",
+      couleur: COULEURS[agences.length % COULEURS.length],
+    });
+    charger();
+  }
+
+  async function modifier(id: string, patch: Record<string, unknown>) {
+    setAgences((list) => list.map((a) => (a.id === id ? { ...a, ...patch } : a)));
+    await fetch(`/api/admin/agences/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+  }
+
+  async function supprimer(a: Agence) {
+    const suite =
+      a.prosCount > 0
+        ? `\n${a.prosCount} paysagiste(s) y sont rattachés : ils ne seront pas supprimés, seulement détachés.`
+        : "";
+    if (!window.confirm(`Supprimer le secteur « ${a.nom} » ?${suite}`)) return;
+    const res = await fetch(`/api/admin/agences/${a.id}`, { method: "DELETE" });
+    if (res.ok) setAgences((list) => list.filter((x) => x.id !== a.id));
+  }
+
+  return (
+    <section className="card space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <h2 className="font-bold">Secteurs d&apos;intervention</h2>
+        {!nouveau && (
+          <button className="btn-secondary !px-3 !py-1.5 text-sm" onClick={() => setNouveau(true)}>
+            Ajouter un secteur
+          </button>
+        )}
+      </div>
+
+      <p className="text-sm text-leaf-800/70">
+        Un secteur = une ville et son rayon d&apos;action (Bordeaux, Béziers…). Dès qu&apos;un
+        secteur existe, un client est accepté s&apos;il est couvert par <b>au moins un</b> secteur —
+        la zone unique ci-dessous n&apos;est alors plus utilisée.
+      </p>
+
+      {chargement && <p className="text-sm text-leaf-800/60">Chargement…</p>}
+
+      {!chargement && agences.length === 0 && !nouveau && (
+        <p className="rounded-xl bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          Aucun secteur. L&apos;application utilise la zone unique définie plus bas — elle ne
+          couvre qu&apos;une seule région. <b>Pour travailler sur deux villes éloignées, créez un
+          secteur par ville.</b>
+        </p>
+      )}
+
+      <div className="space-y-2">
+        {agences.map((a) => (
+          <div key={a.id} className="rounded-xl border border-leaf-200 bg-white p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <span className="h-3.5 w-3.5 shrink-0 rounded-full" style={{ background: a.couleur }} />
+              <input
+                className="input !w-auto flex-1 !py-1.5 font-semibold"
+                value={a.nom}
+                onChange={(e) => modifier(a.id, { nom: e.target.value })}
+              />
+              <span className="text-xs text-leaf-800/60">
+                {a.prosCount} paysagiste{a.prosCount > 1 ? "s" : ""}
+              </span>
+              <label className="flex items-center gap-1.5 text-xs text-leaf-800/70">
+                <input
+                  type="checkbox"
+                  checked={a.actif}
+                  onChange={(e) => modifier(a.id, { actif: e.target.checked })}
+                />
+                Actif
+              </label>
+              <button onClick={() => supprimer(a)} className="text-xs text-red-600 underline">
+                Supprimer
+              </button>
+            </div>
+
+            <div className="mt-2 grid gap-2 sm:grid-cols-3">
+              <label className="text-xs text-leaf-800/60">
+                Code postal du secteur
+                <input
+                  className="input !py-1.5"
+                  value={a.postalCode}
+                  onChange={(e) => modifier(a.id, { postalCode: e.target.value })}
+                  placeholder="33000"
+                />
+              </label>
+              <label className="text-xs text-leaf-800/60">
+                Rayon (km)
+                <input
+                  className="input !py-1.5"
+                  type="number"
+                  min={0}
+                  max={300}
+                  value={a.radiusKm}
+                  onChange={(e) => modifier(a.id, { radiusKm: Number(e.target.value) })}
+                />
+              </label>
+              <label className="text-xs text-leaf-800/60">
+                Départements ou codes postaux
+                <input
+                  className="input !py-1.5"
+                  defaultValue={codesDe(a.postalCodesJson)}
+                  onBlur={(e) => modifier(a.id, { postalCodes: e.target.value })}
+                  placeholder="33, 40"
+                />
+              </label>
+            </div>
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              <span className="text-xs text-leaf-800/60">Couleur dans l&apos;agenda :</span>
+              {COULEURS.map((c) => (
+                <button
+                  key={c}
+                  aria-label={`Couleur ${c}`}
+                  onClick={() => modifier(a.id, { couleur: c })}
+                  className={`h-5 w-5 rounded-full border-2 ${
+                    a.couleur === c ? "border-leaf-900" : "border-transparent"
+                  }`}
+                  style={{ background: c }}
+                />
+              ))}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {nouveau && (
+        <div className="rounded-xl border-2 border-leaf-300 bg-leaf-50/40 p-3">
+          <p className="mb-2 font-semibold">Nouveau secteur</p>
+          <div className="grid gap-2 sm:grid-cols-2">
+            <label className="text-xs text-leaf-800/60">
+              Nom
+              <input
+                className="input !py-1.5"
+                placeholder="Bordeaux"
+                value={brouillon.nom}
+                onChange={(e) => setBrouillon({ ...brouillon, nom: e.target.value })}
+              />
+            </label>
+            <label className="text-xs text-leaf-800/60">
+              Code postal
+              <input
+                className="input !py-1.5"
+                placeholder="33000"
+                value={brouillon.postalCode}
+                onChange={(e) => setBrouillon({ ...brouillon, postalCode: e.target.value })}
+              />
+            </label>
+            <label className="text-xs text-leaf-800/60">
+              Rayon (km)
+              <input
+                className="input !py-1.5"
+                type="number"
+                min={0}
+                max={300}
+                value={brouillon.radiusKm}
+                onChange={(e) => setBrouillon({ ...brouillon, radiusKm: Number(e.target.value) })}
+              />
+            </label>
+            <label className="text-xs text-leaf-800/60">
+              Départements ou codes postaux (facultatif)
+              <input
+                className="input !py-1.5"
+                placeholder="33, 40"
+                value={brouillon.postalCodes}
+                onChange={(e) => setBrouillon({ ...brouillon, postalCodes: e.target.value })}
+              />
+            </label>
+          </div>
+          {erreur && <p className="mt-2 text-sm font-semibold text-red-600">{erreur}</p>}
+          <div className="mt-3 flex gap-2">
+            <button className="btn-primary !w-auto !px-4 !py-2 text-sm" onClick={creer}>
+              Créer le secteur
+            </button>
+            <button
+              className="btn-secondary !px-4 !py-2 text-sm"
+              onClick={() => {
+                setNouveau(false);
+                setErreur("");
+              }}
+            >
+              Annuler
+            </button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/src/app/admin/parametres/page.tsx
+++ b/app/src/app/admin/parametres/page.tsx
@@ -3,6 +3,7 @@
 // Paramètres gérant : entreprise, Google Agenda, horaires, zones, messages.
 import { useEffect, useRef, useState } from "react";
 import PhotoUpload from "@/components/PhotoUpload";
+import AgencesSection from "./AgencesSection";
 
 /** Redimensionne le logo côté client (max 600 px de large, PNG). */
 async function fileToLogoDataUrl(file: File): Promise<string> {
@@ -306,7 +307,9 @@ export default function AdminSettingsPage() {
           <PhotoUpload photos={gallery} onChange={updateGallery} label="6 photos maximum" maxPhotos={6} />
         </section>
 
-        {/* Zone d'intervention */}
+        <AgencesSection />
+
+        {/* Zone d'intervention (repli si aucun secteur) */}
         <section className="card space-y-3">
           <h2 className="font-bold">Zone d&apos;intervention</h2>
           <div className="flex gap-2">

--- a/app/src/app/admin/pros/page.tsx
+++ b/app/src/app/admin/pros/page.tsx
@@ -14,6 +14,7 @@ type Pro = {
   basePostalCode: string;
   radiusKm: number;
   availableDays: number;
+  agenceId: string | null;
   datesJson: string;
   devisDispoJson: string;
   note: string;
@@ -39,8 +40,11 @@ function fmtCreneaux(json: string, days: string[]): string {
     .join(" | ") + (days.length > 4 ? `… (+${days.length - 4} jour(s))` : "");
 }
 
+type AgenceLite = { id: string; nom: string; couleur: string };
+
 export default function AdminProsPage() {
   const [pros, setPros] = useState<Pro[]>([]);
+  const [agences, setAgences] = useState<AgenceLite[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
 
@@ -63,7 +67,21 @@ export default function AdminProsPage() {
       })
       .then((data) => setPros(data.pros ?? []))
       .finally(() => setLoading(false));
+    fetch("/api/admin/agences")
+      .then((r) => (r.ok ? r.json() : { agences: [] }))
+      .then((d) => setAgences(d.agences ?? []))
+      .catch(() => {});
   }, []);
+
+  /** Rattacher un paysagiste à un secteur (agenda d'équipe). */
+  async function changerAgence(id: string, agenceId: string) {
+    setPros((list) => list.map((p) => (p.id === id ? { ...p, agenceId: agenceId || null } : p)));
+    await fetch(`/api/admin/pros/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ agenceId }),
+    });
+  }
 
   // « Disponible » = a réellement coché quelque chose à venir dans son agenda.
   const today = new Date().toISOString().slice(0, 10);
@@ -121,6 +139,21 @@ export default function AdminProsPage() {
                   {" · "}
                   <a className="text-leaf-700 underline" href={`mailto:${p.email}`}>{p.email}</a>
                 </p>
+                {agences.length > 0 && (
+                  <p className="flex flex-wrap items-center gap-2">
+                    <span className="text-leaf-800/60">Secteur :</span>
+                    <select
+                      className="input !w-auto !py-1 text-sm"
+                      value={p.agenceId ?? ""}
+                      onChange={(e) => changerAgence(p.id, e.target.value)}
+                    >
+                      <option value="">— Non rattaché —</option>
+                      {agences.map((a) => (
+                        <option key={a.id} value={a.id}>{a.nom}</option>
+                      ))}
+                    </select>
+                  </p>
+                )}
                 <p className="text-leaf-800/70">{resume.detail}</p>
                 <p>Jours de chantier : {fmtJours(resume.jours)}</p>
                 <p>Créneaux de visite : {fmtCreneaux(p.devisDispoJson, resume.joursDevis)}</p>

--- a/app/src/app/api/admin/agences/[id]/route.ts
+++ b/app/src/app/api/admin/agences/[id]/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { champsAgence } from "@/lib/agences";
+
+export const dynamic = "force-dynamic";
+
+// PATCH /api/admin/agences/:id — modifier un secteur.
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+  const existe = await prisma.agence.findUnique({ where: { id: params.id } });
+  if (!existe) return NextResponse.json({ error: "introuvable" }, { status: 404 });
+
+  const agence = await prisma.agence.update({
+    where: { id: params.id },
+    data: champsAgence(body),
+  });
+  return NextResponse.json({ agence });
+}
+
+// DELETE /api/admin/agences/:id — supprimer un secteur.
+// Les paysagistes rattachés ne sont PAS supprimés : ils sont simplement
+// détachés (agenceId repasse à null).
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const existe = await prisma.agence.findUnique({ where: { id: params.id } });
+  if (!existe) return NextResponse.json({ error: "introuvable" }, { status: 404 });
+  await prisma.agence.delete({ where: { id: params.id } });
+  return NextResponse.json({ ok: true });
+}

--- a/app/src/app/api/admin/agences/route.ts
+++ b/app/src/app/api/admin/agences/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { champsAgence } from "@/lib/agences";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/admin/agences — les secteurs, avec le nombre de paysagistes rattachés.
+export async function GET() {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const agences = await prisma.agence.findMany({
+    orderBy: [{ ordre: "asc" }, { nom: "asc" }],
+    include: { _count: { select: { pros: true } } },
+  });
+  return NextResponse.json({
+    agences: agences.map(({ _count, ...a }) => ({ ...a, prosCount: _count.pros })),
+  });
+}
+
+// POST /api/admin/agences — créer un secteur.
+export async function POST(req: NextRequest) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+  const data = champsAgence(body);
+  if (!data.nom) {
+    return NextResponse.json({ error: "Le nom du secteur est obligatoire." }, { status: 400 });
+  }
+  const agence = await prisma.agence.create({
+    data: { ...data, nom: String(data.nom) },
+  });
+  return NextResponse.json({ agence }, { status: 201 });
+}

--- a/app/src/app/api/admin/pros/[id]/route.ts
+++ b/app/src/app/api/admin/pros/[id]/route.ts
@@ -4,6 +4,31 @@ import { isAdminAuthenticated } from "@/lib/auth";
 
 export const dynamic = "force-dynamic";
 
+// PATCH /api/admin/pros/:id { agenceId } — rattacher un paysagiste à un
+// secteur (ou l'en détacher avec une valeur vide).
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  let body: Record<string, unknown> = {};
+  try {
+    body = await req.json();
+  } catch {}
+  if (body.agenceId === undefined) {
+    return NextResponse.json({ error: "Rien à modifier" }, { status: 400 });
+  }
+  const brut = String(body.agenceId ?? "").trim();
+  const agenceId = brut
+    ? ((await prisma.agence.findUnique({ where: { id: brut } })) ? brut : null)
+    : null;
+  try {
+    const pro = await prisma.pro.update({ where: { id: params.id }, data: { agenceId } });
+    return NextResponse.json({ ok: true, agenceId: pro.agenceId });
+  } catch {
+    return NextResponse.json({ error: "introuvable" }, { status: 404 });
+  }
+}
+
 // DELETE /api/admin/pros/:id — retire un professionnel (ses pointages suivent).
 export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
   if (!isAdminAuthenticated()) {

--- a/app/src/app/api/agences/route.ts
+++ b/app/src/app/api/agences/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server";
+import { agencesActives } from "@/lib/agences";
+
+export const dynamic = "force-dynamic";
+
+// GET /api/agences — liste publique et minimale des secteurs, pour le
+// sélecteur de l'inscription professionnelle. Aucune donnée sensible.
+export async function GET() {
+  const agences = await agencesActives();
+  return NextResponse.json({
+    agences: agences.map((a) => ({ id: a.id, nom: a.nom, city: a.city, postalCode: a.postalCode })),
+  });
+}

--- a/app/src/app/api/pro/register/route.ts
+++ b/app/src/app/api/pro/register/route.ts
@@ -25,6 +25,7 @@ export async function POST(req: NextRequest) {
   const postalCode = String(body.postalCode ?? "").trim();
   const city = String(body.city ?? "").trim();
   const radiusKm = Math.max(0, Math.min(200, Number(body.radiusKm) || 30));
+  const agenceId = String(body.agenceId ?? "").trim() || null;
 
   if (!name || !/.+@.+\..+/.test(email) || password.length < 6) {
     return NextResponse.json(
@@ -51,6 +52,8 @@ export async function POST(req: NextRequest) {
       basePostalCode: postalCode,
       baseCity: city,
       radiusKm,
+      // Secteur choisi à l'inscription (Bordeaux, Béziers…), s'il en existe.
+      agenceId: agenceId && (await prisma.agence.findUnique({ where: { id: agenceId } })) ? agenceId : null,
       passwordHash: hashPassword(password),
     },
   });

--- a/app/src/app/pro/login/page.tsx
+++ b/app/src/app/pro/login/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 // Connexion / inscription libre des professionnels.
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import AddressAutocomplete, { type AddressValue } from "@/components/AddressAutocomplete";
 
@@ -13,9 +13,19 @@ export default function ProLoginPage() {
   const [phone, setPhone] = useState("");
   const [addr, setAddr] = useState<AddressValue>({ address: "", postalCode: "", city: "" });
   const [radiusKm, setRadiusKm] = useState(30);
+  // Secteurs proposés à l'inscription (Bordeaux, Béziers…), s'il en existe.
+  const [agences, setAgences] = useState<{ id: string; nom: string; city: string }[]>([]);
+  const [agenceId, setAgenceId] = useState("");
   const [password, setPassword] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch("/api/agences")
+      .then((r) => (r.ok ? r.json() : { agences: [] }))
+      .then((d) => setAgences(d.agences ?? []))
+      .catch(() => {});
+  }, []);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -35,6 +45,7 @@ export default function ProLoginPage() {
           postalCode: addr.postalCode,
           city: addr.city,
           radiusKm,
+          agenceId,
         }),
       });
       const data = await res.json();
@@ -97,6 +108,29 @@ export default function ProLoginPage() {
             <p className="-mt-1 text-xs text-leaf-800/60">
               Elle indique votre secteur d&apos;intervention au gérant.
             </p>
+            {agences.length > 0 && (
+              <div>
+                <label className="label" htmlFor="agence">Secteur *</label>
+                <select
+                  id="agence"
+                  className="input"
+                  value={agenceId}
+                  onChange={(e) => setAgenceId(e.target.value)}
+                  required
+                >
+                  <option value="">— Choisissez votre secteur —</option>
+                  {agences.map((a) => (
+                    <option key={a.id} value={a.id}>
+                      {a.nom}
+                      {a.city ? ` (${a.city})` : ""}
+                    </option>
+                  ))}
+                </select>
+                <p className="mt-1 text-xs text-leaf-800/60">
+                  L&apos;équipe à laquelle vous êtes rattaché, pour l&apos;agenda partagé.
+                </p>
+              </div>
+            )}
             <div>
               <label className="label" htmlFor="radius">Rayon d&apos;intervention (km)</label>
               <input

--- a/app/src/lib/agences.ts
+++ b/app/src/lib/agences.ts
@@ -1,0 +1,114 @@
+// Secteurs d'exploitation (agences). Un client est couvert si AU MOINS UNE
+// agence le couvre. Tant qu'aucune agence n'est créée, l'application retombe
+// sur la zone unique historique de Settings.
+import type { Agence } from "@prisma/client";
+import { prisma } from "./prisma";
+import { cpToLatLng, distanceKm } from "./geo";
+
+/** Nettoie une liste de codes postaux saisie « 33, 40 » ou « 33 40 ». */
+export function normaliserCodes(v: unknown): string[] {
+  const brut = Array.isArray(v) ? v.map(String) : String(v ?? "").split(/[,;\s]+/);
+  return Array.from(
+    new Set(brut.map((c) => c.trim()).filter((c) => /^\d{2,5}$/.test(c)))
+  );
+}
+
+/** Champs modifiables d'une agence, validés (création et modification). */
+export function champsAgence(body: Record<string, unknown>): Record<string, unknown> {
+  const data: Record<string, unknown> = {};
+  if (typeof body.nom === "string" && body.nom.trim()) data.nom = body.nom.trim().slice(0, 60);
+  if (typeof body.couleur === "string" && /^#[0-9a-fA-F]{6}$/.test(body.couleur)) {
+    data.couleur = body.couleur;
+  }
+  if (typeof body.address === "string") data.address = body.address.trim().slice(0, 200);
+  if (typeof body.city === "string") data.city = body.city.trim().slice(0, 80);
+  if (typeof body.postalCode === "string") {
+    const cp = body.postalCode.trim();
+    data.postalCode = cp;
+    // Coordonnées déduites de la table de CP embarquée : aucun service externe.
+    const pos = cpToLatLng(cp);
+    data.lat = pos?.lat ?? null;
+    data.lng = pos?.lng ?? null;
+  }
+  if (Number.isFinite(Number(body.radiusKm))) {
+    data.radiusKm = Math.max(0, Math.min(300, Math.round(Number(body.radiusKm))));
+  }
+  if (body.postalCodes !== undefined) {
+    data.postalCodesJson = JSON.stringify(normaliserCodes(body.postalCodes));
+  }
+  if (typeof body.actif === "boolean") data.actif = body.actif;
+  if (Number.isFinite(Number(body.ordre))) data.ordre = Math.round(Number(body.ordre));
+  return data;
+}
+
+export type AgenceCouverture = {
+  agence: Agence;
+  /** Distance CP client ↔ CP agence, ou null si l'un des deux est inconnu. */
+  distance: number | null;
+  raison: "code_postal" | "rayon" | "aucune_restriction" | null;
+};
+
+export function parseCodes(json: string): string[] {
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr)
+      ? arr.map((c) => String(c).trim()).filter(Boolean)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Les agences actives, dans l'ordre d'affichage choisi par le gérant. */
+export async function agencesActives(): Promise<Agence[]> {
+  return prisma.agence.findMany({
+    where: { actif: true },
+    orderBy: [{ ordre: "asc" }, { nom: "asc" }],
+  });
+}
+
+/** Un code postal correspond-il à la liste (préfixe accepté : « 33 » couvre 33000) ? */
+export function cpCouvert(codes: string[], cp: string): boolean {
+  return codes.some((c) => (c.length === 5 ? c === cp : cp.startsWith(c)));
+}
+
+/**
+ * L'agence couvre-t-elle ce code postal ? Deux façons, non exclusives :
+ * la liste de codes postaux, ou le rayon autour de l'agence (distance
+ * calculée avec la table de CP embarquée, sans service externe).
+ */
+export function couvertureDe(agence: Agence, cp: string): AgenceCouverture {
+  const codes = parseCodes(agence.postalCodesJson);
+  const posAgence =
+    agence.lat != null && agence.lng != null
+      ? { lat: agence.lat, lng: agence.lng }
+      : cpToLatLng(agence.postalCode);
+  const posClient = cpToLatLng(cp);
+  const distance =
+    posAgence && posClient ? Math.round(distanceKm(posAgence, posClient) * 10) / 10 : null;
+
+  if (codes.length && cpCouvert(codes, cp)) {
+    return { agence, distance, raison: "code_postal" };
+  }
+  if (agence.radiusKm > 0 && distance !== null && distance <= agence.radiusKm) {
+    return { agence, distance, raison: "rayon" };
+  }
+  // Agence sans aucune restriction : elle couvre tout.
+  if (!codes.length && agence.radiusKm <= 0) {
+    return { agence, distance, raison: "aucune_restriction" };
+  }
+  return { agence, distance, raison: null };
+}
+
+/**
+ * L'agence la plus pertinente pour un code postal : celle qui le couvre et
+ * dont le siège est le plus proche. Null si aucune ne le couvre.
+ */
+export async function agencePour(cp: string): Promise<AgenceCouverture | null> {
+  const agences = await agencesActives();
+  const couvrantes = agences
+    .map((a) => couvertureDe(a, cp))
+    .filter((c) => c.raison !== null)
+    .sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity));
+  return couvrantes[0] ?? null;
+}

--- a/app/src/lib/zone.ts
+++ b/app/src/lib/zone.ts
@@ -1,5 +1,7 @@
 import type { Settings } from "@prisma/client";
 import { parsePostalCodes } from "./settings";
+import { agencesActives, couvertureDe } from "./agences";
+import { cpToLatLng } from "./geo";
 
 export type ZoneResult = { covered: boolean; reason?: string };
 
@@ -35,6 +37,13 @@ function haversineKm(a: { lat: number; lng: number }, b: { lat: number; lng: num
 
 /**
  * Vérifie si une adresse/code postal est dans la zone d'intervention.
+ *
+ * Dès qu'au moins une agence existe, c'est elle qui fait foi : le client est
+ * couvert si N'IMPORTE QUELLE agence le couvre (liste de codes postaux ou
+ * rayon). C'est ce qui permet d'exploiter plusieurs secteurs éloignés —
+ * Bordeaux et Béziers — sans que l'un exclue l'autre.
+ *
+ * Sans agence, on retombe sur la zone unique historique :
  * - mode "postal" : le code postal doit figurer dans la liste (préfixe accepté, ex. "44" couvre tout le 44)
  * - mode "radius" : distance à vol d'oiseau depuis l'adresse de base <= rayon
  */
@@ -42,9 +51,24 @@ export async function checkZone(
   settings: Settings,
   postalCode: string,
   fullAddress?: string
-): Promise<ZoneResult & { lat?: number; lng?: number }> {
+): Promise<ZoneResult & { lat?: number; lng?: number; agenceId?: string }> {
   const cp = postalCode.trim();
   if (!/^\d{5}$/.test(cp)) return { covered: false, reason: "code_postal_invalide" };
+
+  const agences = await agencesActives();
+  if (agences.length > 0) {
+    const couvrantes = agences
+      .map((a) => couvertureDe(a, cp))
+      .filter((c) => c.raison !== null)
+      .sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity));
+    if (couvrantes.length === 0) return { covered: false, reason: "hors_zone" };
+    const pos = cpToLatLng(cp);
+    return {
+      covered: true,
+      agenceId: couvrantes[0].agence.id,
+      ...(pos ? { lat: pos.lat, lng: pos.lng } : {}),
+    };
+  }
 
   if (settings.zoneMode === "radius" && settings.baseLat != null && settings.baseLng != null) {
     const point = fullAddress ? await geocode(fullAddress) : null;


### PR DESCRIPTION
Première phase du plan CRM. La zone d'intervention était un préfixe unique (`34`) : **un client bordelais était refusé « hors zone »**. La couverture devient l'union des secteurs actifs.

## Ce qui change

- **Modèle `Agence`** : nom, couleur, adresse de référence, rayon, départements ou codes postaux couverts. Les coordonnées sont déduites de la table de codes postaux déjà embarquée — aucun service externe, aucune clé à fournir.
- **`checkZone`** accepte un client couvert par **au moins un** secteur actif et renvoie le plus proche. **Sans aucun secteur, le comportement historique est conservé à l'identique** : rien ne change pour l'installation actuelle tant que le gérant n'a rien créé.
- **Gestion des secteurs** dans les paramètres : ajout, renommage, rayon, codes postaux, couleur d'agenda, activation, suppression (les paysagistes rattachés sont détachés, pas supprimés).
- **Rattachement des paysagistes** : sélecteur de secteur à l'inscription (masqué s'il n'existe aucun secteur), et modifiable par le gérant depuis la liste des professionnels.

Le rattachement prépare les agendas d'équipe de la phase 3.

## Tests effectués (PostgreSQL local)

| Cas | Attendu | Obtenu |
| --- | --- | --- |
| Bordeaux (33000) **avant** création des secteurs | refusé | `hors_zone` |
| Bordeaux (33000) **après** création des deux secteurs | accepté | RDV créé |
| Gironde éloignée (33780 Soulac, ~85 km) | accepté par le préfixe `33` | RDV créé |
| Béziers (34500) | toujours accepté | accepté |
| Lyon (69001) | toujours refusé | `hors_zone` |

Également vérifié au navigateur : création des deux secteurs, modification d'un rayon conservée après rechargement, et sélecteur de secteur présent à l'inscription professionnelle.

`npm run build` OK.

## Suite

Phases 1 à 3 (base « Tous les clients », espace « Affaires », agendas d'équipe) à venir dans des lots séparés, comme prévu dans la note d'architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_