### PR TITLE
Phase 2 — Espace « Affaires » et pipeline commercial

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -107,6 +107,7 @@ model Agence {
   ordre           Int      @default(0)
   pros            Pro[]
   contacts        Contact[]
+  affaires        Affaire[]
 }
 
 // « Tous les clients » : la base de contacts exhaustive. Tout ce qui entre —
@@ -132,10 +133,47 @@ model Contact {
   agence       Agence?  @relation(fields: [agenceId], references: [id], onDelete: SetNull)
   notes        String   @default("")
   bookings     Booking[]
+  affaires     Affaire[]
   interactions Interaction[]
 
   @@index([phoneKey])
   @@index([email])
+}
+
+// « Affaires / Projets » : un projet commercial identifié pour un contact.
+// Un contact peut en porter PLUSIEURS (taille de haie en mars, contrat annuel
+// en juin, réaménagement l'année suivante) — c'est ce qui distingue une base
+// clients d'un simple carnet d'adresses.
+model Affaire {
+  id            String    @id @default(cuid())
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  contactId     String
+  contact       Contact   @relation(fields: [contactId], references: [id], onDelete: Cascade)
+  intitule      String    @default("")
+  // Adresse du chantier : parfois différente de celle du contact.
+  address       String    @default("")
+  postalCode    String    @default("")
+  city          String    @default("")
+  projectType   String    @default("autre")
+  description   String    @default("")
+  // Étape du pipeline (voir lib/pipeline.ts). « perdu » exige un motif.
+  statut        String    @default("nouvelle")
+  motifPerte    String    @default("")
+  // Montant estimé puis réel (repris du devis chiffré).
+  montant       Float?
+  // Date de la prochaine action à mener : le champ qui empêche une affaire
+  // de mourir en silence.
+  prochaineActionAt DateTime?
+  agenceId      String?
+  agence        Agence?   @relation(fields: [agenceId], references: [id], onDelete: SetNull)
+  proId         String?
+  pro           Pro?      @relation(fields: [proId], references: [id], onDelete: SetNull)
+  bookings      Booking[]
+  documents     Document[]
+
+  @@index([statut])
+  @@index([contactId])
 }
 
 // Journal des échanges d'un contact : appels, emails, SMS, notes libres.
@@ -172,6 +210,9 @@ model Booking {
   // par le RDV (adresse du chantier, qui peut différer de celle du contact).
   contactId      String?
   contact        Contact?  @relation(fields: [contactId], references: [id], onDelete: SetNull)
+  // Affaire commerciale dont ce rendez-vous fait partie.
+  affaireId      String?
+  affaire        Affaire?  @relation(fields: [affaireId], references: [id], onDelete: SetNull)
   kind           String    @default("devis") // devis | chantier
   // web = réservé sur le site ; manual = créé à la main par le gérant
   source         String    @default("web")
@@ -252,6 +293,7 @@ model Pro {
   updatedAt      DateTime @updatedAt
   workEntries    WorkEntry[]
   bookings       Booking[]
+  affaires       Affaire[]
 }
 
 // Pointage terrain d'un professionnel : une ligne par jour (heure de Paris).
@@ -308,6 +350,9 @@ model Document {
   notes         String   @default("")
   // devis : brouillon | envoye | accepte | refuse — facture : a_payer | payee
   status        String   @default("brouillon")
+  // Affaire à laquelle ce devis ou cette facture se rapporte.
+  affaireId     String?
+  affaire       Affaire? @relation(fields: [affaireId], references: [id], onDelete: SetNull)
   updatedAt     DateTime @updatedAt
 }
 

--- a/app/src/app/admin/AdminNav.tsx
+++ b/app/src/app/admin/AdminNav.tsx
@@ -64,6 +64,12 @@ const ICONS: Record<string, JSX.Element> = {
       <path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" />
     </svg>
   ),
+  affaires: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5 shrink-0">
+      <rect x="2" y="7" width="20" height="14" rx="2" />
+      <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
+    </svg>
+  ),
   logout: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5 shrink-0">
       <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
@@ -75,6 +81,7 @@ const ICONS: Record<string, JSX.Element> = {
 const LINKS = [
   { href: "/admin", label: "Tableau de bord", icon: "dashboard" },
   { href: "/admin/clients", label: "Tous les clients", icon: "clients" },
+  { href: "/admin/affaires", label: "Affaires", icon: "affaires" },
   { href: "/admin/planning", label: "Agenda", icon: "agenda" },
   { href: "/admin/terrain", label: "Gestion terrain", icon: "terrain" },
   { href: "/admin/stats", label: "Statistiques", icon: "stats" },

--- a/app/src/app/admin/affaires/FicheAffaire.tsx
+++ b/app/src/app/admin/affaires/FicheAffaire.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+// Détail d'une affaire : montant, date de prochaine action, rendez-vous et
+// documents liés. Le reste du dossier client vit dans « Tous les clients ».
+import { useEffect, useState } from "react";
+import { MOTIFS_PERTE } from "@/lib/pipeline";
+
+type Detail = {
+  id: string;
+  intitule: string;
+  description: string;
+  statut: string;
+  motifPerte: string;
+  montant: number | null;
+  prochaineActionAt: string | null;
+  address: string;
+  postalCode: string;
+  city: string;
+  contact: { id: string; firstName: string; lastName: string; phone: string; email: string };
+  pro: { id: string; name: string } | null;
+  bookings: { id: string; kind: string; startAt: string | null; status: string; city: string }[];
+  documents: { id: string; type: string; number: string; status: string; date: string }[];
+};
+
+function isoJour(iso: string | null): string {
+  return iso ? new Date(iso).toISOString().slice(0, 10) : "";
+}
+
+export default function FicheAffaire({ id, onChange }: { id: string; onChange: () => void }) {
+  const [d, setD] = useState<Detail | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/admin/affaires/${id}`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((res) => res && setD(res.affaire))
+      .catch(() => {});
+  }, [id]);
+
+  if (!d) return <p className="mt-2 text-xs text-leaf-800/60">Chargement…</p>;
+
+  async function enregistrer(patch: Record<string, unknown>) {
+    setD((a) => (a ? { ...a, ...patch } : a));
+    await fetch(`/api/admin/affaires/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+    onChange();
+  }
+
+  return (
+    <div className="mt-2 space-y-2 border-t border-leaf-100 pt-2 text-xs">
+      <label className="block text-leaf-800/60">
+        Intitulé
+        <input
+          className="input !py-1 text-xs"
+          defaultValue={d.intitule}
+          onBlur={(e) => enregistrer({ intitule: e.target.value })}
+        />
+      </label>
+      <div className="grid grid-cols-2 gap-2">
+        <label className="text-leaf-800/60">
+          Montant (€)
+          <input
+            className="input !py-1 text-xs"
+            type="number"
+            min={0}
+            defaultValue={d.montant ?? ""}
+            onBlur={(e) => enregistrer({ montant: e.target.value === "" ? null : Number(e.target.value) })}
+          />
+        </label>
+        <label className="text-leaf-800/60">
+          Prochaine action
+          <input
+            className="input !py-1 text-xs"
+            type="date"
+            defaultValue={isoJour(d.prochaineActionAt)}
+            onBlur={(e) => enregistrer({ prochaineActionAt: e.target.value })}
+          />
+        </label>
+      </div>
+
+      {d.statut === "perdu" && (
+        <label className="block text-leaf-800/60">
+          Motif de la perte
+          <select
+            className="input !py-1 text-xs"
+            value={d.motifPerte}
+            onChange={(e) => enregistrer({ motifPerte: e.target.value })}
+          >
+            <option value="">— À préciser —</option>
+            {Object.entries(MOTIFS_PERTE).map(([id2, label]) => (
+              <option key={id2} value={id2}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </label>
+      )}
+
+      {d.contact.phone && (
+        <p>
+          <a className="font-semibold text-leaf-700 underline" href={`tel:${d.contact.phone}`}>
+            {d.contact.phone}
+          </a>
+          {d.city ? ` · ${d.city}` : ""}
+        </p>
+      )}
+
+      {d.bookings.length > 0 && (
+        <div>
+          <p className="font-semibold text-leaf-800/60">Rendez-vous</p>
+          {d.bookings.map((b) => (
+            <p key={b.id} className={b.kind === "chantier" ? "text-green-800" : "text-blue-800"}>
+              {b.kind === "chantier" ? "Chantier" : "Visite"} ·{" "}
+              {b.startAt
+                ? new Date(b.startAt).toLocaleDateString("fr-FR", { day: "numeric", month: "short" })
+                : "sans date"}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {d.documents.length > 0 && (
+        <div>
+          <p className="font-semibold text-leaf-800/60">Documents</p>
+          {d.documents.map((doc) => (
+            <a key={doc.id} className="block text-leaf-700 underline" href={`/admin/facturation/${doc.id}`}>
+              {doc.type === "facture" ? "Facture" : "Devis"} {doc.number}
+            </a>
+          ))}
+        </div>
+      )}
+
+      <a className="inline-block font-semibold text-leaf-700 underline" href="/admin/clients">
+        Voir la fiche client
+      </a>
+    </div>
+  );
+}

--- a/app/src/app/admin/affaires/page.tsx
+++ b/app/src/app/admin/affaires/page.tsx
@@ -1,0 +1,356 @@
+"use client";
+
+// « Affaires / Projets » : le pipeline commercial. Seuls les dossiers réellement
+// engagés y figurent — les simples contacts restent dans « Tous les clients ».
+import { useEffect, useState } from "react";
+import { ETAPES, ETAPE_PAR_ID, COULEURS_GROUPE, MOTIFS_PERTE, type Groupe } from "@/lib/pipeline";
+import FicheAffaire from "./FicheAffaire";
+
+export type Affaire = {
+  id: string;
+  intitule: string;
+  statut: string;
+  motifPerte: string;
+  montant: number | null;
+  prochaineActionAt: string | null;
+  city: string;
+  postalCode: string;
+  groupe: Groupe;
+  rdvCount: number;
+  documentsCount: number;
+  contact: { id: string; firstName: string; lastName: string; phone: string; email: string };
+  agence: { id: string; nom: string; couleur: string } | null;
+  pro: { id: string; name: string } | null;
+};
+
+type AgenceLite = { id: string; nom: string; couleur: string };
+
+const BANDES: { groupe: Groupe; titre: string; aide: string }[] = [
+  { groupe: "commercial", titre: "Commercial", aide: "à traiter, relancer, chiffrer" },
+  { groupe: "execution", titre: "Exécution", aide: "gagnées, chantier à mener" },
+];
+
+function euros(n: number | null): string {
+  if (n === null || n === undefined) return "—";
+  return n.toLocaleString("fr-FR", { style: "currency", currency: "EUR", maximumFractionDigits: 0 });
+}
+
+function jour(iso: string | null): string {
+  if (!iso) return "";
+  return new Date(iso).toLocaleDateString("fr-FR", { day: "numeric", month: "short" });
+}
+
+/** Une action due aujourd'hui ou en retard doit sauter aux yeux. */
+function enRetard(iso: string | null): boolean {
+  if (!iso) return false;
+  return new Date(iso).getTime() <= Date.now();
+}
+
+export default function AdminAffairesPage() {
+  const [affaires, setAffaires] = useState<Affaire[]>([]);
+  const [compteurs, setCompteurs] = useState<Record<string, number>>({});
+  const [agences, setAgences] = useState<AgenceLite[]>([]);
+  const [vue, setVue] = useState<"actives" | "toutes">("actives");
+  const [q, setQ] = useState("");
+  const [agence, setAgence] = useState("");
+  const [ouvert, setOuvert] = useState<string | null>(null);
+  const [chargement, setChargement] = useState(true);
+  const [reprise, setReprise] = useState("");
+  const [repriseEnCours, setRepriseEnCours] = useState(false);
+
+  function charger() {
+    const p = new URLSearchParams({ vue });
+    if (q.trim()) p.set("q", q.trim());
+    if (agence) p.set("agence", agence);
+    fetch(`/api/admin/affaires?${p.toString()}`)
+      .then((r) => {
+        if (r.status === 401) {
+          window.location.href = "/admin/login";
+          throw new Error("unauthorized");
+        }
+        return r.json();
+      })
+      .then((d) => {
+        setAffaires(d.affaires ?? []);
+        setCompteurs(d.compteurs ?? {});
+      })
+      .catch(() => {})
+      .finally(() => setChargement(false));
+  }
+
+  useEffect(() => {
+    fetch("/api/admin/agences")
+      .then((r) => (r.ok ? r.json() : { agences: [] }))
+      .then((d) => setAgences(d.agences ?? []))
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    const t = setTimeout(charger, 300);
+    return () => clearTimeout(t);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [vue, q, agence]);
+
+  async function lancerReprise() {
+    if (
+      !window.confirm(
+        "Créer les affaires à partir des rendez-vous existants ?\nL'opération peut être relancée sans risque."
+      )
+    )
+      return;
+    setRepriseEnCours(true);
+    const res = await fetch("/api/admin/affaires/reprise", { method: "POST" });
+    const d = await res.json();
+    setRepriseEnCours(false);
+    setReprise(d.message ?? d.error ?? "Reprise impossible.");
+    charger();
+  }
+
+  /** Déplacer une affaire d'une étape à l'autre. */
+  async function changerEtape(a: Affaire, statut: string) {
+    let motifPerte = a.motifPerte;
+    if (statut === "perdu" && !MOTIFS_PERTE[motifPerte]) {
+      const choix = window.prompt(
+        "Pourquoi cette affaire est-elle perdue ?\n" +
+          Object.entries(MOTIFS_PERTE)
+            .map(([id, l], i) => `${i + 1}. ${l}`)
+            .join("\n") +
+          "\n\nTapez le numéro :",
+        "3"
+      );
+      const cles = Object.keys(MOTIFS_PERTE);
+      const idx = Number(choix) - 1;
+      if (!(idx >= 0 && idx < cles.length)) return;
+      motifPerte = cles[idx];
+    }
+    const res = await fetch(`/api/admin/affaires/${a.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ statut, motifPerte }),
+    });
+    if (res.ok) charger();
+  }
+
+  const aRelancer = affaires.filter((a) => enRetard(a.prochaineActionAt));
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-6">
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold">Affaires ({affaires.length})</h1>
+          <p className="text-sm text-leaf-800/60">
+            Les demandes réellement engagées. Les autres restent dans « Tous les clients ».
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            className="btn-secondary !px-3 !py-2 text-sm"
+            onClick={lancerReprise}
+            disabled={repriseEnCours}
+          >
+            {repriseEnCours ? "Reprise…" : "Reprendre l'existant"}
+          </button>
+        </div>
+      </div>
+
+      {reprise && (
+        <p className="mb-3 rounded-xl bg-leaf-50 px-4 py-3 text-sm font-medium text-leaf-800">{reprise}</p>
+      )}
+
+      {aRelancer.length > 0 && (
+        <div className="mb-4 rounded-xl border-2 border-amber-300 bg-amber-50 px-4 py-3">
+          <p className="text-sm font-bold text-amber-900">
+            {aRelancer.length} affaire(s) à relancer aujourd&apos;hui
+          </p>
+          <p className="mt-0.5 text-sm text-amber-900/80">
+            {aRelancer
+              .slice(0, 4)
+              .map((a) => `${a.contact.firstName} ${a.contact.lastName}`.trim() || a.intitule)
+              .join(" · ")}
+            {aRelancer.length > 4 ? ` +${aRelancer.length - 4}` : ""}
+          </p>
+        </div>
+      )}
+
+      <div className="mb-4 flex flex-wrap gap-2">
+        <input
+          className="input flex-1 !w-auto"
+          placeholder="Rechercher : client, ville, intitulé…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <div className="flex rounded-xl bg-leaf-50 p-1">
+          {(["actives", "toutes"] as const).map((v) => (
+            <button
+              key={v}
+              onClick={() => setVue(v)}
+              className={`rounded-lg px-3 py-1.5 text-sm font-semibold transition ${
+                vue === v ? "bg-white shadow-sm" : "text-leaf-800/60"
+              }`}
+            >
+              {v === "actives" ? "En cours" : "Toutes"}
+            </button>
+          ))}
+        </div>
+        {agences.length > 0 && (
+          <select className="input !w-auto" value={agence} onChange={(e) => setAgence(e.target.value)}>
+            <option value="">Tous secteurs</option>
+            {agences.map((a) => (
+              <option key={a.id} value={a.id}>
+                {a.nom}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {chargement && <p className="py-8 text-center text-leaf-800/60">Chargement…</p>}
+
+      {!chargement && affaires.length === 0 && (
+        <div className="card py-8 text-center text-sm text-leaf-800/60">
+          {q || agence ? (
+            "Aucune affaire ne correspond."
+          ) : (
+            <>
+              Aucune affaire. Si vous aviez déjà des rendez-vous, cliquez sur{" "}
+              <b>Reprendre l&apos;existant</b> pour les transformer en affaires.
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Pipeline : une colonne par étape, groupées en bandes */}
+      <div className="space-y-6">
+        {BANDES.map((bande) => {
+          const etapes = ETAPES.filter((e) => e.groupe === bande.groupe);
+          const dansLaBande = affaires.filter((a) => a.groupe === bande.groupe);
+          if (vue === "actives" && dansLaBande.length === 0 && !chargement) return null;
+          return (
+            <section key={bande.groupe}>
+              <div className="mb-2 flex items-baseline gap-2">
+                <h2
+                  className="text-xs font-bold uppercase tracking-wider"
+                  style={{ color: COULEURS_GROUPE[bande.groupe].puce }}
+                >
+                  {bande.titre}
+                </h2>
+                <span className="text-xs text-leaf-800/50">{bande.aide}</span>
+                <span className="ml-auto text-xs font-semibold text-leaf-800/60">
+                  {dansLaBande.length}
+                </span>
+              </div>
+              <div className="flex gap-3 overflow-x-auto pb-2">
+                {etapes.map((etape) => {
+                  const liste = dansLaBande.filter((a) => a.statut === etape.id);
+                  return (
+                    <div key={etape.id} className="w-64 shrink-0">
+                      <div className="mb-1.5 flex items-baseline justify-between gap-2 px-0.5">
+                        <span className="text-sm font-bold">{etape.court}</span>
+                        <span className="text-xs text-leaf-800/50">
+                          {compteurs[etape.id] ?? 0}
+                        </span>
+                      </div>
+                      <p className="mb-1.5 px-0.5 text-[11px] leading-tight text-leaf-800/50">
+                        {etape.aide}
+                      </p>
+                      <div className="space-y-1.5">
+                        {liste.map((a) => (
+                          <div key={a.id} className="card !p-2.5">
+                            <button
+                              className="w-full text-left"
+                              onClick={() => setOuvert(ouvert === a.id ? null : a.id)}
+                            >
+                              <p className="text-sm font-semibold">
+                                {`${a.contact.firstName} ${a.contact.lastName}`.trim() || "Sans nom"}
+                              </p>
+                              <p className="text-xs text-leaf-800/70">{a.intitule}</p>
+                              <div className="mt-1 flex flex-wrap items-center gap-1.5 text-[11px]">
+                                {a.montant !== null && (
+                                  <span className="font-semibold text-leaf-800">{euros(a.montant)}</span>
+                                )}
+                                {a.agence && (
+                                  <span
+                                    className="rounded-full px-1.5 py-0.5 font-semibold text-white"
+                                    style={{ background: a.agence.couleur }}
+                                  >
+                                    {a.agence.nom}
+                                  </span>
+                                )}
+                                {a.prochaineActionAt && (
+                                  <span
+                                    className={`rounded-full px-1.5 py-0.5 font-semibold ${
+                                      enRetard(a.prochaineActionAt)
+                                        ? "bg-amber-200 text-amber-900"
+                                        : "bg-sand-50 text-leaf-800/70"
+                                    }`}
+                                  >
+                                    {enRetard(a.prochaineActionAt) ? "À relancer " : "Suivi "}
+                                    {jour(a.prochaineActionAt)}
+                                  </span>
+                                )}
+                              </div>
+                            </button>
+                            <select
+                              className="input mt-1.5 !py-1 text-xs"
+                              value={a.statut}
+                              onChange={(e) => changerEtape(a, e.target.value)}
+                            >
+                              {ETAPES.map((e) => (
+                                <option key={e.id} value={e.id}>
+                                  {e.label}
+                                </option>
+                              ))}
+                            </select>
+                            {ouvert === a.id && (
+                              <FicheAffaire id={a.id} onChange={charger} />
+                            )}
+                          </div>
+                        ))}
+                        {liste.length === 0 && (
+                          <p className="rounded-xl border border-dashed border-leaf-200 py-3 text-center text-[11px] text-leaf-800/40">
+                            vide
+                          </p>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            </section>
+          );
+        })}
+
+        {vue === "toutes" && (
+          <section>
+            <h2 className="mb-2 text-xs font-bold uppercase tracking-wider text-leaf-800/60">
+              Clôturées
+            </h2>
+            <div className="space-y-1.5">
+              {affaires
+                .filter((a) => a.groupe.startsWith("clos"))
+                .map((a) => (
+                  <div key={a.id} className="card !p-2.5">
+                    <div className="flex flex-wrap items-center gap-2 text-sm">
+                      <span className="font-semibold">
+                        {`${a.contact.firstName} ${a.contact.lastName}`.trim() || "Sans nom"}
+                      </span>
+                      <span className="text-leaf-800/60">{a.intitule}</span>
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-[11px] font-semibold ${
+                          COULEURS_GROUPE[a.groupe].badge
+                        }`}
+                      >
+                        {ETAPE_PAR_ID[a.statut]?.label}
+                        {a.motifPerte ? ` — ${MOTIFS_PERTE[a.motifPerte]}` : ""}
+                      </span>
+                      <span className="ml-auto font-semibold">{euros(a.montant)}</span>
+                    </div>
+                  </div>
+                ))}
+            </div>
+          </section>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/app/src/app/admin/stats/page.tsx
+++ b/app/src/app/admin/stats/page.tsx
@@ -11,6 +11,15 @@ type Stats = {
   weeks: Week[];
   months: Month[];
   statuses: Record<string, number>;
+  crm: {
+    contacts: number;
+    affaires: number;
+    actives: number;
+    gagnees: number;
+    perdues: number;
+    taux: number | null;
+    pipelineMontant: number;
+  };
   totals: {
     bookings: number;
     upcoming: number;
@@ -103,6 +112,42 @@ export default function AdminStatsPage() {
     <main className="mx-auto max-w-4xl px-4 py-6">
       <h1 className="text-xl font-bold">Statistiques</h1>
       <p className="mb-5 text-sm text-leaf-800/60">Activité des 12 dernières semaines et facturation de l&apos;année.</p>
+
+      {/* Entonnoir : ce qui entre, ce qui devient un projet, ce qui se signe */}
+      {stats.crm.affaires > 0 && (
+        <section className="card mb-6">
+          <h2 className="mb-1 font-bold">De la demande au chantier</h2>
+          <p className="mb-3 text-sm text-leaf-800/60">
+            Toutes les demandes reçues ne deviennent pas des projets — voici où elles vont.
+          </p>
+          <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+            <Tile
+              label="Clients en base"
+              value={String(stats.crm.contacts)}
+              hint="Tous les contacts entrants"
+            />
+            <Tile
+              label="Projets engagés"
+              value={String(stats.crm.affaires)}
+              hint={`${stats.crm.actives} encore en cours`}
+            />
+            <Tile
+              label="Taux de transformation"
+              value={stats.crm.taux === null ? "—" : `${stats.crm.taux} %`}
+              hint={
+                stats.crm.gagnees + stats.crm.perdues
+                  ? `${stats.crm.gagnees} gagnées sur ${stats.crm.gagnees + stats.crm.perdues} décidées`
+                  : "Aucune affaire encore décidée"
+              }
+            />
+            <Tile
+              label="En jeu"
+              value={euros(stats.crm.pipelineMontant)}
+              hint="Montant des affaires en cours"
+            />
+          </div>
+        </section>
+      )}
 
       <div className="mb-6 grid grid-cols-2 gap-3 lg:grid-cols-4">
         <Tile

--- a/app/src/app/api/admin/affaires/[id]/route.ts
+++ b/app/src/app/api/admin/affaires/[id]/route.ts
@@ -1,0 +1,105 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { changerStatut } from "@/lib/affaires";
+import { ETAPE_PAR_ID, MOTIFS_PERTE } from "@/lib/pipeline";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/affaires/:id — le dossier complet. */
+export async function GET(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const affaire = await prisma.affaire.findUnique({
+    where: { id: params.id },
+    include: {
+      contact: true,
+      agence: { select: { id: true, nom: true, couleur: true } },
+      pro: { select: { id: true, name: true } },
+      bookings: {
+        orderBy: { startAt: "asc" },
+        select: { id: true, kind: true, startAt: true, endAt: true, status: true, city: true },
+      },
+      documents: {
+        orderBy: { createdAt: "desc" },
+        select: { id: true, type: true, number: true, status: true, date: true, itemsJson: true, vatRate: true },
+      },
+    },
+  });
+  if (!affaire) return NextResponse.json({ error: "introuvable" }, { status: 404 });
+  return NextResponse.json({ affaire });
+}
+
+/**
+ * PATCH /api/admin/affaires/:id — étape, motif de perte, montant, date de
+ * prochaine action, paysagiste responsable, intitulé.
+ */
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+  const existe = await prisma.affaire.findUnique({ where: { id: params.id } });
+  if (!existe) return NextResponse.json({ error: "introuvable" }, { status: 404 });
+
+  // Changement d'étape : passe par la fonction dédiée, qui journalise.
+  if (typeof body.statut === "string" && body.statut !== existe.statut) {
+    const statut = body.statut;
+    if (!ETAPE_PAR_ID[statut]) {
+      return NextResponse.json({ error: "Étape inconnue" }, { status: 400 });
+    }
+    const motif = String(body.motifPerte ?? existe.motifPerte ?? "");
+    if (statut === "perdu" && !MOTIFS_PERTE[motif]) {
+      return NextResponse.json(
+        { error: "Indiquez pourquoi l'affaire est perdue.", besoinMotif: true },
+        { status: 400 }
+      );
+    }
+    await changerStatut(params.id, statut, { motifPerte: motif });
+  }
+
+  const data: Record<string, unknown> = {};
+  for (const c of ["intitule", "description", "address", "postalCode", "city", "projectType"]) {
+    if (typeof body[c] === "string") data[c] = String(body[c]).trim().slice(0, 2000);
+  }
+  if (body.montant !== undefined) {
+    const n = Number(body.montant);
+    data.montant = Number.isFinite(n) && n >= 0 ? n : null;
+  }
+  if (body.prochaineActionAt !== undefined) {
+    const v = String(body.prochaineActionAt ?? "").trim();
+    data.prochaineActionAt = /^\d{4}-\d{2}-\d{2}$/.test(v) ? new Date(`${v}T09:00:00Z`) : null;
+  }
+  if (body.proId !== undefined) {
+    const brut = String(body.proId ?? "").trim();
+    data.proId = brut && (await prisma.pro.findUnique({ where: { id: brut } })) ? brut : null;
+  }
+  if (body.motifPerte !== undefined && typeof body.statut !== "string") {
+    const m = String(body.motifPerte ?? "");
+    data.motifPerte = MOTIFS_PERTE[m] ? m : "";
+  }
+
+  const affaire = Object.keys(data).length
+    ? await prisma.affaire.update({ where: { id: params.id }, data })
+    : await prisma.affaire.findUnique({ where: { id: params.id } });
+  return NextResponse.json({ ok: true, affaire });
+}
+
+/** DELETE /api/admin/affaires/:id — supprimer une affaire créée par erreur. */
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  try {
+    await prisma.affaire.delete({ where: { id: params.id } });
+    return NextResponse.json({ ok: true });
+  } catch {
+    return NextResponse.json({ error: "introuvable" }, { status: 404 });
+  }
+}

--- a/app/src/app/api/admin/affaires/reprise/route.ts
+++ b/app/src/app/api/admin/affaires/reprise/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { creerAffaire, intituleAuto } from "@/lib/affaires";
+import { REPRISE_STATUTS } from "@/lib/pipeline";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 60;
+
+/**
+ * POST /api/admin/affaires/reprise — crée les affaires à partir des rendez-vous
+ * existants. Un rendez-vous « à faire / devis envoyé / gagné / perdu / annulé »
+ * devient une affaire à l'étape correspondante.
+ *
+ * Règle de regroupement : les rendez-vous d'un même client qui se suivent dans
+ * le même dossier (une visite devis puis son chantier) rejoignent la MÊME
+ * affaire ; un rendez-vous éloigné dans le temps en ouvre une nouvelle.
+ *
+ * Idempotent : les rendez-vous déjà rattachés sont ignorés.
+ */
+export async function POST() {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+
+  const bookings = await prisma.booking.findMany({
+    where: { affaireId: null, contactId: { not: null } },
+    orderBy: { createdAt: "asc" },
+  });
+
+  // Deux rendez-vous du même client à plus de 90 jours d'écart sont deux
+  // projets différents (une taille de haie au printemps, une autre à l'automne).
+  const ECART_MAX = 90 * 24 * 3600_000;
+  const derniere = new Map<string, { id: string; quand: number }>();
+  let creees = 0;
+  let rattaches = 0;
+
+  for (const b of bookings) {
+    const quand = (b.startAt ?? b.createdAt).getTime();
+    const precedente = derniere.get(b.contactId!);
+    let affaireId: string;
+
+    if (precedente && Math.abs(quand - precedente.quand) <= ECART_MAX) {
+      affaireId = precedente.id;
+    } else {
+      const affaire = await creerAffaire({
+        contactId: b.contactId!,
+        projectType: b.projectType,
+        description: b.description,
+        address: b.address,
+        postalCode: b.postalCode,
+        city: b.city,
+        statut: REPRISE_STATUTS[b.status] ?? "nouvelle",
+        proId: b.proId,
+      });
+      affaireId = affaire.id;
+      creees++;
+    }
+
+    await prisma.booking.update({ where: { id: b.id }, data: { affaireId } });
+    derniere.set(b.contactId!, { id: affaireId, quand });
+    rattaches++;
+  }
+
+  // Les affaires reprennent l'intitulé du projet et le montant du devis chiffré
+  // quand il en existe un pour ce client.
+  const sansMontant = await prisma.affaire.findMany({
+    where: { montant: null },
+    include: { contact: { select: { email: true, phone: true } } },
+  });
+  let montants = 0;
+  for (const a of sansMontant) {
+    if (!a.contact.email && !a.contact.phone) continue;
+    const doc = await prisma.document.findFirst({
+      where: {
+        type: "devis",
+        OR: [
+          ...(a.contact.email ? [{ clientEmail: a.contact.email }] : []),
+          ...(a.contact.phone ? [{ clientPhone: a.contact.phone }] : []),
+        ],
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    if (!doc) continue;
+    let total = 0;
+    try {
+      for (const l of JSON.parse(doc.itemsJson) as { qty: number; unitPrice: number }[]) {
+        total += (Number(l.qty) || 0) * (Number(l.unitPrice) || 0);
+      }
+    } catch {}
+    await prisma.affaire.update({
+      where: { id: a.id },
+      data: {
+        montant: total || null,
+        intitule: a.intitule || intituleAuto(a.projectType, a.city),
+      },
+    });
+    await prisma.document.update({ where: { id: doc.id }, data: { affaireId: a.id } });
+    montants++;
+  }
+
+  const total = await prisma.affaire.count();
+  return NextResponse.json({
+    ok: true,
+    creees,
+    rattaches,
+    montants,
+    total,
+    message:
+      `${creees} affaire(s) créée(s) à partir de ${rattaches} rendez-vous, ` +
+      `${montants} devis chiffré(s) rattaché(s). Total : ${total} affaire(s).`,
+  });
+}

--- a/app/src/app/api/admin/affaires/route.ts
+++ b/app/src/app/api/admin/affaires/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { creerAffaire } from "@/lib/affaires";
+import { ETAPE_PAR_ID, estActive } from "@/lib/pipeline";
+
+export const dynamic = "force-dynamic";
+
+const MAX_RESULTATS = 300;
+
+/**
+ * GET /api/admin/affaires?vue=actives|toutes&q=&agence=&statut= — le pipeline.
+ * Par défaut on ne renvoie que les affaires vivantes : c'est ce que le gérant
+ * regarde tous les jours.
+ */
+export async function GET(req: NextRequest) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const p = req.nextUrl.searchParams;
+  const vue = p.get("vue") ?? "actives";
+  const q = (p.get("q") ?? "").trim();
+  const agenceId = (p.get("agence") ?? "").trim();
+  const statut = (p.get("statut") ?? "").trim();
+
+  const contient = { contains: q, mode: "insensitive" as const };
+  const where = {
+    AND: [
+      q
+        ? {
+            OR: [
+              { intitule: contient },
+              { city: contient },
+              { postalCode: contient },
+              { description: contient },
+              { contact: { is: { firstName: contient } } },
+              { contact: { is: { lastName: contient } } },
+              { contact: { is: { phone: contient } } },
+              { contact: { is: { email: contient } } },
+            ],
+          }
+        : {},
+      agenceId ? { agenceId } : {},
+      statut ? { statut } : {},
+    ],
+  };
+
+  const affaires = await prisma.affaire.findMany({
+    where,
+    orderBy: [{ prochaineActionAt: "asc" }, { updatedAt: "desc" }],
+    take: MAX_RESULTATS,
+    include: {
+      contact: { select: { id: true, firstName: true, lastName: true, phone: true, email: true } },
+      agence: { select: { id: true, nom: true, couleur: true } },
+      pro: { select: { id: true, name: true } },
+      _count: { select: { bookings: true, documents: true } },
+    },
+  });
+
+  const visibles = vue === "toutes" ? affaires : affaires.filter((a) => estActive(a.statut));
+
+  // Compteurs par étape, calculés sur toute la base (pas sur la page affichée).
+  const parStatut = await prisma.affaire.groupBy({ by: ["statut"], _count: { _all: true } });
+
+  return NextResponse.json({
+    affaires: visibles.map(({ _count, ...a }) => ({
+      ...a,
+      rdvCount: _count.bookings,
+      documentsCount: _count.documents,
+      groupe: ETAPE_PAR_ID[a.statut]?.groupe ?? "commercial",
+    })),
+    compteurs: Object.fromEntries(parStatut.map((r) => [r.statut, r._count._all])),
+  });
+}
+
+/** POST /api/admin/affaires — ouvrir une affaire pour un contact existant. */
+export async function POST(req: NextRequest) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+  const contactId = String(body.contactId ?? "").trim();
+  const contact = contactId
+    ? await prisma.contact.findUnique({ where: { id: contactId } })
+    : null;
+  if (!contact) {
+    return NextResponse.json({ error: "Choisissez d'abord un client." }, { status: 400 });
+  }
+  const affaire = await creerAffaire({
+    contactId: contact.id,
+    projectType: String(body.projectType ?? "autre"),
+    description: String(body.description ?? ""),
+    address: String(body.address ?? contact.address),
+    postalCode: String(body.postalCode ?? contact.postalCode),
+    city: String(body.city ?? contact.city),
+    statut: String(body.statut ?? "nouvelle"),
+  });
+  return NextResponse.json({ ok: true, affaire }, { status: 201 });
+}

--- a/app/src/app/api/admin/bookings/route.ts
+++ b/app/src/app/api/admin/bookings/route.ts
@@ -4,6 +4,7 @@ import { isAdminAuthenticated } from "@/lib/auth";
 import { getSettings } from "@/lib/settings";
 import { parisTimeToUtc } from "@/lib/dates";
 import { creerOuCompleterContact, journaliser } from "@/lib/contacts";
+import { affairePourRdv } from "@/lib/affaires";
 
 export const dynamic = "force-dynamic";
 
@@ -179,6 +180,7 @@ export async function POST(req: NextRequest) {
     include: { photos: { select: { id: true, dataUrl: true } } },
   });
   if (contact) {
+    await affairePourRdv({ ...booking, proId: null });
     await journaliser(
       contact.id,
       "devis",

--- a/app/src/app/api/admin/stats/route.ts
+++ b/app/src/app/api/admin/stats/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { isAdminAuthenticated } from "@/lib/auth";
+import { estActive, estGagnee, estPerdue } from "@/lib/pipeline";
 import { itemsOf, totalHt } from "@/lib/documents";
 import { todayParis, addDaysStr, utcToParis } from "@/lib/dates";
 
@@ -107,10 +108,35 @@ export async function GET() {
     .filter((m) => m.month.startsWith(today.slice(0, 4)))
     .reduce((acc, m) => acc + m.facture, 0);
 
+  // Entonnoir CRM : combien de demandes reçues, combien de projets réellement
+  // engagés, et quel taux de transformation sur les seules affaires décidées.
+  const contactsTotal = await prisma.contact.count();
+  const affaires = await prisma.affaire.findMany({ select: { statut: true, montant: true } });
+  const affairesGagnees = affaires.filter((a) => estGagnee(a.statut)).length;
+  const affairesPerdues = affaires.filter((a) => estPerdue(a.statut)).length;
+  const affairesActives = affaires.filter((a) => estActive(a.statut)).length;
+  const affairesDecidees = affairesGagnees + affairesPerdues;
+  const tauxAffaires = affairesDecidees
+    ? Math.round((affairesGagnees / affairesDecidees) * 100)
+    : null;
+  // Valeur du pipeline : ce qui est encore en jeu.
+  const pipelineMontant = affaires
+    .filter((a) => estActive(a.statut))
+    .reduce((acc, a) => acc + (a.montant ?? 0), 0);
+
   return NextResponse.json({
     weeks,
     months,
     statuses,
+    crm: {
+      contacts: contactsTotal,
+      affaires: affaires.length,
+      actives: affairesActives,
+      gagnees: affairesGagnees,
+      perdues: affairesPerdues,
+      taux: tauxAffaires,
+      pipelineMontant,
+    },
     totals: {
       bookings: bookings.length,
       upcoming,

--- a/app/src/app/api/bookings/route.ts
+++ b/app/src/app/api/bookings/route.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/notifications";
 import { assignChantiers, assignDevis, proDeLaVisite } from "@/lib/assign";
 import { creerOuCompleterContact, journaliser } from "@/lib/contacts";
+import { affairePourRdv } from "@/lib/affaires";
 
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
@@ -175,6 +176,8 @@ export async function POST(req: NextRequest) {
         : Array.from(new Set(attribution.parJour.filter((r) => r.pro).map((r) => r.pro!.name))).join(", ") +
           (nonAttribues ? ` (+ ${nonAttribues} jour(s) à attribuer)` : "");
 
+    // L'affaire commerciale : ouverte si le client n'en a pas déjà une.
+    await affairePourRdv({ ...primary, proId: attribution.parJour[0]?.pro?.id ?? null });
     await journaliser(
       contact.id,
       "rdv",
@@ -213,6 +216,7 @@ export async function POST(req: NextRequest) {
   if (proVisite) await notifyProNewDevis(proVisite, booking, settings);
 
   // 5. SMS de confirmation immédiat + email avec .ics — sans action du gérant.
+  await affairePourRdv({ ...booking, proId: proVisite?.id ?? null });
   await journaliser(
     contact.id,
     "rdv",

--- a/app/src/lib/affaires.ts
+++ b/app/src/lib/affaires.ts
@@ -1,0 +1,142 @@
+// Création et progression des affaires. Une affaire naît dès qu'un PROJET est
+// identifié (un besoin + une adresse) : un simple renseignement tarifaire reste
+// un contact sans affaire, sinon le pipeline se remplit de bruit.
+import type { Affaire, Booking } from "@prisma/client";
+import { prisma } from "./prisma";
+import { agencePour } from "./agences";
+import { journaliser } from "./contacts";
+import { ETAPE_PAR_ID } from "./pipeline";
+
+const LIBELLES_PROJET: Record<string, string> = {
+  entretien: "Entretien de jardin",
+  taille_haie: "Taille de haie",
+  debroussaillage: "Débroussaillage",
+  contrat_annuel: "Contrat d'entretien",
+  autre: "Projet",
+};
+
+export function intituleAuto(projectType: string, city: string): string {
+  const base = LIBELLES_PROJET[projectType] ?? "Projet";
+  return city ? `${base} — ${city}` : base;
+}
+
+/**
+ * L'affaire d'un contact que ce nouveau rendez-vous doit rejoindre, s'il y en
+ * a une. On ne rouvre jamais une affaire close : une nouvelle demande d'un
+ * ancien client est une NOUVELLE affaire — c'est tout l'intérêt d'avoir séparé
+ * le contact du projet.
+ *
+ * La règle dépend du type de rendez-vous :
+ * - une VISITE DEVIS ne rejoint qu'une affaire encore au stade commercial ;
+ *   demander un devis alors qu'un chantier est déjà lancé, c'est un autre projet ;
+ * - un CHANTIER rejoint aussi une affaire en cours d'exécution, puisqu'il en
+ *   est la suite naturelle (le devis vient d'être accepté).
+ */
+export async function affaireOuverteDe(
+  contactId: string,
+  kind: string = "devis"
+): Promise<Affaire | null> {
+  const affaires = await prisma.affaire.findMany({
+    where: { contactId },
+    orderBy: { updatedAt: "desc" },
+  });
+  const groupesAcceptes =
+    kind === "chantier" ? ["commercial", "execution"] : ["commercial"];
+  return (
+    affaires.find((a) => groupesAcceptes.includes(ETAPE_PAR_ID[a.statut]?.groupe ?? "")) ?? null
+  );
+}
+
+export type NouvelleAffaire = {
+  contactId: string;
+  projectType?: string;
+  description?: string;
+  address?: string;
+  postalCode?: string;
+  city?: string;
+  statut?: string;
+  proId?: string | null;
+};
+
+/** Crée l'affaire et la rattache au secteur déduit du code postal. */
+export async function creerAffaire(entree: NouvelleAffaire): Promise<Affaire> {
+  const cp = (entree.postalCode ?? "").trim();
+  const agence = cp ? await agencePour(cp) : null;
+  const affaire = await prisma.affaire.create({
+    data: {
+      contactId: entree.contactId,
+      intitule: intituleAuto(entree.projectType ?? "autre", entree.city ?? ""),
+      projectType: entree.projectType ?? "autre",
+      description: entree.description ?? "",
+      address: entree.address ?? "",
+      postalCode: cp,
+      city: entree.city ?? "",
+      statut: entree.statut ?? "nouvelle",
+      agenceId: agence?.agence.id ?? null,
+      proId: entree.proId ?? null,
+    },
+  });
+  return affaire;
+}
+
+/**
+ * Rattache un rendez-vous à une affaire : celle déjà ouverte pour ce contact,
+ * sinon une nouvelle. Fait avancer l'étape selon le type de rendez-vous.
+ */
+export async function affairePourRdv(
+  booking: Pick<Booking, "id" | "contactId" | "kind" | "projectType" | "description" | "address" | "postalCode" | "city" | "proId">
+): Promise<Affaire | null> {
+  if (!booking.contactId) return null;
+  const statutVise = booking.kind === "chantier" ? "chantier_planifie" : "visite_planifiee";
+
+  let affaire = await affaireOuverteDe(booking.contactId, booking.kind);
+  if (!affaire) {
+    affaire = await creerAffaire({
+      contactId: booking.contactId,
+      projectType: booking.projectType,
+      description: booking.description,
+      address: booking.address,
+      postalCode: booking.postalCode,
+      city: booking.city,
+      statut: statutVise,
+      proId: booking.proId,
+    });
+  } else {
+    // On n'écrase une étape que si le rendez-vous fait avancer le dossier.
+    const ordreActuel = ETAPE_PAR_ID[affaire.statut]?.ordre ?? 0;
+    const ordreVise = ETAPE_PAR_ID[statutVise]?.ordre ?? 0;
+    const data: Record<string, unknown> = {};
+    if (ordreVise > ordreActuel) data.statut = statutVise;
+    if (booking.proId && !affaire.proId) data.proId = booking.proId;
+    if (Object.keys(data).length) {
+      affaire = await prisma.affaire.update({ where: { id: affaire.id }, data });
+    }
+  }
+  await prisma.booking.update({ where: { id: booking.id }, data: { affaireId: affaire.id } });
+  return affaire;
+}
+
+/** Change l'étape d'une affaire et journalise le mouvement chez le contact. */
+export async function changerStatut(
+  affaireId: string,
+  statut: string,
+  options?: { motifPerte?: string }
+): Promise<Affaire | null> {
+  const affaire = await prisma.affaire.findUnique({ where: { id: affaireId } });
+  if (!affaire || !ETAPE_PAR_ID[statut]) return null;
+  const maj = await prisma.affaire.update({
+    where: { id: affaireId },
+    data: {
+      statut,
+      motifPerte: statut === "perdu" ? options?.motifPerte ?? affaire.motifPerte : "",
+    },
+  });
+  await journaliser(
+    affaire.contactId,
+    "note",
+    `Affaire « ${affaire.intitule} » : ${ETAPE_PAR_ID[statut].label}` +
+      (statut === "perdu" && maj.motifPerte ? ` (${maj.motifPerte})` : ""),
+    { auteur: "gerant" }
+  );
+  return maj;
+}

--- a/app/src/lib/pipeline.ts
+++ b/app/src/lib/pipeline.ts
@@ -1,0 +1,110 @@
+// Pipeline commercial d'une affaire. Un seul champ `statut`, dont les valeurs
+// se lisent en trois bandes : commercial, exécution, clôturé.
+//
+// Deux principes issus de la note d'architecture :
+//   1. « Refusé », « pas intéressé » et « pas de réponse » ne sont pas des
+//      étapes mais des MOTIFS de perte — sinon le pipeline se remplit de
+//      colonnes mortes et les pertes deviennent incomptables ;
+//   2. « Accepté » n'est pas une fin : le devis accepté déclenche le chantier.
+
+export type Groupe = "commercial" | "execution" | "clos_gagne" | "clos_perdu" | "clos_neutre";
+
+export type Etape = {
+  id: string;
+  label: string;
+  court: string;
+  groupe: Groupe;
+  /** Ordre d'affichage dans le pipeline. */
+  ordre: number;
+  aide: string;
+};
+
+export const ETAPES: Etape[] = [
+  { id: "nouvelle", label: "Nouvelle demande", court: "Nouvelle", groupe: "commercial", ordre: 1,
+    aide: "Contact entrant à qualifier" },
+  { id: "visite_planifiee", label: "Visite planifiée", court: "Visite", groupe: "commercial", ordre: 2,
+    aide: "Rendez-vous devis pris" },
+  { id: "devis_a_faire", label: "Devis à faire", court: "À chiffrer", groupe: "commercial", ordre: 3,
+    aide: "Visite passée, chiffrage à produire" },
+  { id: "devis_envoye", label: "Devis envoyé", court: "Envoyé", groupe: "commercial", ordre: 4,
+    aide: "Devis transmis au client" },
+  { id: "relance", label: "En relance", court: "Relance", groupe: "commercial", ordre: 5,
+    aide: "Sans réponse, relance programmée" },
+  { id: "gagne", label: "Gagné, à planifier", court: "Gagné", groupe: "execution", ordre: 6,
+    aide: "Devis accepté, chantier à caler" },
+  { id: "chantier_planifie", label: "Chantier planifié", court: "Planifié", groupe: "execution", ordre: 7,
+    aide: "Dates posées, paysagiste attribué" },
+  { id: "chantier_en_cours", label: "Chantier en cours", court: "En cours", groupe: "execution", ordre: 8,
+    aide: "Travaux démarrés" },
+  { id: "termine", label: "Terminé", court: "Terminé", groupe: "execution", ordre: 9,
+    aide: "Travaux finis" },
+  { id: "facture", label: "Facturé", court: "Facturé", groupe: "clos_gagne", ordre: 10,
+    aide: "Facture émise" },
+  { id: "paye", label: "Payé", court: "Payé", groupe: "clos_gagne", ordre: 11,
+    aide: "Facture réglée — affaire close" },
+  { id: "perdu", label: "Perdu", court: "Perdu", groupe: "clos_perdu", ordre: 12,
+    aide: "Sans suite — indiquez le motif" },
+  { id: "annule", label: "Annulé", court: "Annulé", groupe: "clos_neutre", ordre: 13,
+    aide: "Annulation — neutre dans les statistiques" },
+];
+
+export const ETAPE_PAR_ID: Record<string, Etape> = Object.fromEntries(
+  ETAPES.map((e) => [e.id, e])
+);
+
+export const STATUTS_VALIDES = ETAPES.map((e) => e.id);
+
+/** Motifs de perte : c'est le « pourquoi », séparé de l'étape. */
+export const MOTIFS_PERTE: Record<string, string> = {
+  refuse: "Devis refusé",
+  pas_interesse: "Pas intéressé",
+  pas_de_reponse: "Pas de réponse",
+  trop_cher: "Trop cher",
+  concurrent: "Parti chez un concurrent",
+  hors_zone: "Hors zone d'intervention",
+  injoignable: "Injoignable",
+  autre: "Autre",
+};
+
+/** Une affaire encore vivante : elle a sa place dans le pipeline. */
+export function estActive(statut: string): boolean {
+  const g = ETAPE_PAR_ID[statut]?.groupe;
+  return g === "commercial" || g === "execution";
+}
+
+/** Compte au numérateur du taux de transformation. */
+export function estGagnee(statut: string): boolean {
+  const g = ETAPE_PAR_ID[statut]?.groupe;
+  return g === "execution" || g === "clos_gagne";
+}
+
+/** Compte au dénominateur du taux de transformation. */
+export function estPerdue(statut: string): boolean {
+  return ETAPE_PAR_ID[statut]?.groupe === "clos_perdu";
+}
+
+/**
+ * « Annulé » n'est ni gagné ni perdu : un client qui déménage n'est pas une
+ * affaire perdue commercialement, la compter comme telle dégraderait le taux
+ * sans que le gérant puisse agir.
+ */
+export function compteDansLeTaux(statut: string): boolean {
+  return estGagnee(statut) || estPerdue(statut);
+}
+
+export const COULEURS_GROUPE: Record<Groupe, { puce: string; badge: string; libelle: string }> = {
+  commercial: { puce: "#2563eb", badge: "bg-blue-100 text-blue-800", libelle: "Commercial" },
+  execution: { puce: "#16a34a", badge: "bg-green-100 text-green-800", libelle: "Exécution" },
+  clos_gagne: { puce: "#15803d", badge: "bg-green-200 text-green-900", libelle: "Gagné et clos" },
+  clos_perdu: { puce: "#b91c1c", badge: "bg-red-100 text-red-700", libelle: "Perdu" },
+  clos_neutre: { puce: "#9ca3af", badge: "bg-gray-200 text-gray-700", libelle: "Annulé" },
+};
+
+/** Correspondance entre les anciens statuts de RDV et les nouvelles étapes. */
+export const REPRISE_STATUTS: Record<string, string> = {
+  a_faire: "nouvelle",
+  devis_envoye: "devis_envoye",
+  gagne: "gagne",
+  perdu: "perdu",
+  annule: "annule",
+};


### PR DESCRIPTION
Troisième phase du plan CRM : les dossiers réellement engagés sont séparés des simples contacts.

## Ce qui change

- **Modèle `Affaire`** : contact, intitulé, adresse du chantier, montant, étape, motif de perte, date de prochaine action, secteur, paysagiste responsable. **Un contact porte plusieurs affaires** — c'est tout l'intérêt de la séparation.
- **11 étapes en trois bandes** (commercial / exécution / clôturé), conformes à la note d'architecture.
- **« Refusé », « pas intéressé », « pas de réponse » deviennent des MOTIFS** sur une seule étape « Perdu ». Le tableau reste lisible et les pertes redeviennent comptables ; à l'écran, l'affaire affiche toujours « Perdu — Devis refusé ». Le motif est **obligatoire** au passage en perdu.
- **Règle de rattachement** : une visite devis ne rejoint qu'une affaire encore au stade commercial ; un chantier peut rejoindre une affaire en exécution, puisqu'il en est la suite. Tout le reste ouvre une nouvelle affaire.
- **Reprise de l'existant en un clic** : les rendez-vous d'un même client à moins de 90 jours d'écart forment une affaire, les statuts sont convertis, les devis chiffrés rattachés.
- **Statistiques** : nouvel entonnoir « De la demande au chantier » — clients en base, projets engagés, taux de transformation sur les seules affaires décidées, montant encore en jeu.

## Tests effectués (PostgreSQL local)

Jeu d'essai : Sophie (5 traces, 3 RDV), Paul (1 RDV), Karim (prospect publicitaire jamais converti).

| Vérification | Résultat |
| --- | --- |
| Reprise de 4 RDV | **2 affaires**, RDV correctement regroupés |
| Prospect jamais engagé (Karim) | **aucune affaire** — il reste dans « Tous les clients » seulement |
| Sophie a une affaire **gagnée** puis redemande un devis | **2 affaires distinctes**, l'ancienne n'est pas rouverte |
| Passage en « Perdu » | motif exigé, affaire affichée « Perdu — Devis refusé » |
| Secteurs | affaires rattachées à Bordeaux / Béziers |
| Entonnoir | 3 clients, 3 projets, 50 % (1 gagnée sur 2 décidées) |

Vérifié au navigateur : colonnes du pipeline, déplacement d'une affaire, bandes commercial/exécution, section « Clôturées ».

`npm run build` OK.

## Point d'attention

Le regroupement à 90 jours de la reprise est une heuristique sur l'historique : deux chantiers très espacés pour le même client formeront deux affaires, deux rendez-vous proches une seule. Les nouvelles réservations, elles, suivent la règle stricte décrite plus haut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_