### PR TITLE
Phase 3 — Absences et agenda d'équipe par secteur

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -294,6 +294,26 @@ model Pro {
   workEntries    WorkEntry[]
   bookings       Booking[]
   affaires       Affaire[]
+  absences       Absence[]
+}
+
+// Absence d'un professionnel : congés, arrêt, formation… Contrairement à un
+// jour simplement non coché — qu'on ne peut pas distinguer d'un planning pas
+// encore rempli — une absence bloque l'attribution automatique et s'affiche
+// dans tous les agendas.
+model Absence {
+  id      String   @id @default(cuid())
+  createdAt DateTime @default(now())
+  proId   String
+  pro     Pro      @relation(fields: [proId], references: [id], onDelete: Cascade)
+  // Bornes incluses, au format AAAA-MM-JJ (heure de Paris).
+  du      String
+  au      String
+  // conges | arret | formation | personnel
+  motif   String   @default("conges")
+  note    String   @default("")
+
+  @@index([proId, du])
 }
 
 // Pointage terrain d'un professionnel : une ligne par jour (heure de Paris).

--- a/app/src/app/admin/AdminNav.tsx
+++ b/app/src/app/admin/AdminNav.tsx
@@ -70,6 +70,12 @@ const ICONS: Record<string, JSX.Element> = {
       <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
     </svg>
   ),
+  equipe: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5 shrink-0">
+      <rect x="3" y="4" width="18" height="17" rx="2" />
+      <path d="M3 9h18M9 9v12M15 9v12" />
+    </svg>
+  ),
   logout: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5 shrink-0">
       <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
@@ -83,6 +89,7 @@ const LINKS = [
   { href: "/admin/clients", label: "Tous les clients", icon: "clients" },
   { href: "/admin/affaires", label: "Affaires", icon: "affaires" },
   { href: "/admin/planning", label: "Agenda", icon: "agenda" },
+  { href: "/admin/equipe", label: "Agenda d'équipe", icon: "equipe" },
   { href: "/admin/terrain", label: "Gestion terrain", icon: "terrain" },
   { href: "/admin/stats", label: "Statistiques", icon: "stats" },
   { href: "/admin/meta", label: "Publicités Meta", icon: "meta" },

--- a/app/src/app/admin/equipe/page.tsx
+++ b/app/src/app/admin/equipe/page.tsx
@@ -1,0 +1,409 @@
+"use client";
+
+// Agenda d'équipe : une colonne par paysagiste, vue Jour par défaut. C'est la
+// vue à ouvrir quand un client est au téléphone — les trous se lisent
+// verticalement, sans ouvrir chaque agenda un par un.
+import { useEffect, useMemo, useState } from "react";
+
+type Pro = {
+  id: string;
+  name: string;
+  phone: string;
+  baseCity: string;
+  radiusKm: number;
+  agenceId: string | null;
+  jours: string[];
+  dispo: Record<string, string[]>;
+  absents: string[];
+};
+type Booking = {
+  id: string;
+  proId: string;
+  kind: string;
+  firstName: string;
+  lastName: string;
+  phone: string;
+  city: string;
+  address: string;
+  startAt: string;
+  endAt: string;
+};
+type Agence = { id: string; nom: string; couleur: string };
+type Creneau = {
+  startAt: string;
+  date: string;
+  heure: string;
+  pro: { id: string; name: string; phone: string; distance: number | null } | null;
+};
+
+const HEURE_DEBUT = 7;
+const HEURE_FIN = 20;
+const PX_HEURE = 56;
+
+function ymd(d: Date): string {
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+function ajouter(jour: string, n: number): string {
+  const d = new Date(`${jour}T12:00:00`);
+  d.setDate(d.getDate() + n);
+  return ymd(d);
+}
+function minutesParis(iso: string): number {
+  const s = new Date(iso).toLocaleTimeString("fr-FR", {
+    timeZone: "Europe/Paris",
+    hour12: false,
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+  const [h, m] = s.split(":").map(Number);
+  return h * 60 + m;
+}
+function heureParis(iso: string): string {
+  return new Date(iso)
+    .toLocaleTimeString("fr-FR", { timeZone: "Europe/Paris", hour: "2-digit", minute: "2-digit" })
+    .replace(":", "h");
+}
+function libelleJour(jour: string): string {
+  const l = new Date(`${jour}T12:00:00`).toLocaleDateString("fr-FR", {
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+  return l.charAt(0).toUpperCase() + l.slice(1);
+}
+
+export default function AdminEquipePage() {
+  const [jour, setJour] = useState(() => ymd(new Date()));
+  const [agence, setAgence] = useState("");
+  const [agences, setAgences] = useState<Agence[]>([]);
+  const [pros, setPros] = useState<Pro[]>([]);
+  const [bookings, setBookings] = useState<Booking[]>([]);
+  const [chargement, setChargement] = useState(true);
+  const [cp, setCp] = useState("");
+  const [creneaux, setCreneaux] = useState<Creneau[] | null>(null);
+  const [recherche, setRecherche] = useState(false);
+
+  // Le secteur choisi est mémorisé : le gérant travaille sur une ville à la fois.
+  useEffect(() => {
+    const memorise = window.localStorage.getItem("agenceEquipe") ?? "";
+    setAgence(memorise);
+  }, []);
+
+  useEffect(() => {
+    setChargement(true);
+    const p = new URLSearchParams({ du: jour, au: jour });
+    if (agence) p.set("agence", agence);
+    fetch(`/api/admin/equipe?${p.toString()}`)
+      .then((r) => {
+        if (r.status === 401) {
+          window.location.href = "/admin/login";
+          throw new Error("unauthorized");
+        }
+        return r.json();
+      })
+      .then((d) => {
+        setAgences(d.agences ?? []);
+        setPros(d.pros ?? []);
+        setBookings(d.bookings ?? []);
+      })
+      .catch(() => {})
+      .finally(() => setChargement(false));
+  }, [jour, agence]);
+
+  function choisirAgence(id: string) {
+    setAgence(id);
+    window.localStorage.setItem("agenceEquipe", id);
+  }
+
+  async function chercherCreneaux() {
+    if (!/^\d{5}$/.test(cp.trim())) return;
+    setRecherche(true);
+    setCreneaux(null);
+    const res = await fetch(`/api/admin/equipe/creneaux?cp=${cp.trim()}&n=6`);
+    const d = await res.json();
+    setRecherche(false);
+    setCreneaux(d.creneaux ?? []);
+  }
+
+  const heures = useMemo(
+    () => Array.from({ length: HEURE_FIN - HEURE_DEBUT + 1 }, (_, i) => HEURE_DEBUT + i),
+    []
+  );
+  const parPro = useMemo(() => {
+    const m: Record<string, Booking[]> = {};
+    for (const b of bookings) (m[b.proId] ??= []).push(b);
+    return m;
+  }, [bookings]);
+
+  const aujourdhui = ymd(new Date());
+
+  return (
+    <main className="mx-auto max-w-6xl px-4 py-6">
+      <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-xl font-bold">Agenda d&apos;équipe</h1>
+          <p className="text-sm text-leaf-800/60">
+            Tous les paysagistes du secteur en parallèle, pour proposer un créneau sans ouvrir
+            chaque agenda.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <button className="btn-secondary !px-3 !py-1.5" onClick={() => setJour(ajouter(jour, -1))}>
+            ←
+          </button>
+          <button className="btn-secondary !px-3 !py-1.5" onClick={() => setJour(aujourdhui)}>
+            Aujourd&apos;hui
+          </button>
+          <button className="btn-secondary !px-3 !py-1.5" onClick={() => setJour(ajouter(jour, 1))}>
+            →
+          </button>
+          <input
+            className="input !w-auto !py-1.5"
+            type="date"
+            value={jour}
+            onChange={(e) => e.target.value && setJour(e.target.value)}
+          />
+        </div>
+      </div>
+
+      {agences.length > 0 && (
+        <div className="mb-3 flex flex-wrap gap-1.5">
+          <button
+            onClick={() => choisirAgence("")}
+            className={`rounded-full px-3 py-1.5 text-sm font-semibold transition ${
+              agence === "" ? "bg-leaf-700 text-white" : "bg-leaf-50 text-leaf-800/70"
+            }`}
+          >
+            Tous les secteurs
+          </button>
+          {agences.map((a) => (
+            <button
+              key={a.id}
+              onClick={() => choisirAgence(a.id)}
+              className="rounded-full px-3 py-1.5 text-sm font-semibold transition"
+              style={
+                agence === a.id
+                  ? { background: a.couleur, color: "white" }
+                  : { background: "#f2f6f1", color: "#3d4a3d" }
+              }
+            >
+              {a.nom}
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Premier créneau libre : la fonction du coup de téléphone */}
+      <div className="card mb-4">
+        <p className="mb-2 font-bold">Trouver un créneau pour un client</p>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <input
+            className="input flex-1"
+            placeholder="Code postal du client (ex. 33000)"
+            value={cp}
+            onChange={(e) => setCp(e.target.value)}
+            onKeyDown={(e) => e.key === "Enter" && chercherCreneaux()}
+          />
+          <button
+            className="btn-primary !w-auto !px-4 !py-2.5 text-sm"
+            onClick={chercherCreneaux}
+            disabled={recherche}
+          >
+            {recherche ? "Recherche…" : "Premiers créneaux libres"}
+          </button>
+        </div>
+        {creneaux !== null && (
+          <div className="mt-3">
+            {creneaux.length === 0 ? (
+              <p className="text-sm text-leaf-800/60">
+                Aucun créneau disponible pour ce code postal. Vérifiez qu&apos;il est bien dans un
+                secteur couvert et qu&apos;un paysagiste a déclaré des disponibilités.
+              </p>
+            ) : (
+              <ul className="space-y-1">
+                {creneaux.map((c) => (
+                  <li
+                    key={c.startAt}
+                    className="flex flex-wrap items-center gap-2 rounded-xl bg-blue-50 px-3 py-2 text-sm"
+                  >
+                    <span className="font-bold text-blue-900">
+                      {libelleJour(c.date)} à {c.heure.replace(":", "h")}
+                    </span>
+                    <span className="text-blue-900/80">
+                      {c.pro
+                        ? `avec ${c.pro.name}${c.pro.distance !== null ? ` — ${c.pro.distance} km` : ""}`
+                        : "visite du gérant"}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        )}
+      </div>
+
+      <p className="mb-2 font-semibold capitalize">{libelleJour(jour)}</p>
+
+      <div className="mb-2 flex flex-wrap gap-3 text-xs text-leaf-800/60">
+        <span className="flex items-center gap-1">
+          <span className="h-2.5 w-2.5 rounded-full bg-blue-500" /> Visite devis
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-2.5 w-2.5 rounded-full bg-green-500" /> Chantier
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-2.5 w-2.5 rounded-sm bg-leaf-100" /> Disponibilité déclarée
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="h-2.5 w-2.5 rounded-sm bg-gray-300" /> Absent
+        </span>
+      </div>
+
+      {chargement && <p className="py-8 text-center text-leaf-800/60">Chargement…</p>}
+
+      {!chargement && pros.length === 0 && (
+        <p className="card py-8 text-center text-sm text-leaf-800/60">
+          Aucun paysagiste dans ce secteur. Rattachez-les depuis l&apos;onglet
+          <b> Professionnels</b>.
+        </p>
+      )}
+
+      {!chargement && pros.length > 0 && (
+        <div className="overflow-x-auto rounded-2xl border border-leaf-100 bg-white">
+          <div style={{ minWidth: `${3 + pros.length * 9}rem` }}>
+            {/* En-têtes : un paysagiste par colonne */}
+            <div
+              className="grid border-b border-leaf-100"
+              style={{ gridTemplateColumns: `3rem repeat(${pros.length}, minmax(0, 1fr))` }}
+            >
+              <span />
+              {pros.map((p) => {
+                const absent = p.absents.includes(jour);
+                const dispoJour = (p.dispo[jour] ?? []).length;
+                const chantierJour = p.jours.includes(jour);
+                return (
+                  <div key={p.id} className="border-l border-leaf-100 px-2 py-2 text-center">
+                    <p className="truncate text-sm font-bold" title={p.name}>
+                      {p.name}
+                    </p>
+                    <p className="text-[11px] text-leaf-800/60">
+                      {absent
+                        ? "Absent"
+                        : [
+                            chantierJour ? "chantier" : "",
+                            dispoJour ? `${dispoJour} créneau(x)` : "",
+                          ]
+                            .filter(Boolean)
+                            .join(" · ") || "rien de déclaré"}
+                    </p>
+                  </div>
+                );
+              })}
+            </div>
+
+            {/* Grille horaire */}
+            <div
+              className="relative grid"
+              style={{ gridTemplateColumns: `3rem repeat(${pros.length}, minmax(0, 1fr))` }}
+            >
+              <div className="relative" style={{ height: heures.length * PX_HEURE }}>
+                {heures.map((h, i) => (
+                  <span
+                    key={h}
+                    className="absolute right-1 text-[11px] text-leaf-800/50"
+                    style={{ top: i * PX_HEURE - 6 }}
+                  >
+                    {h}h
+                  </span>
+                ))}
+              </div>
+
+              {pros.map((p) => {
+                const absent = p.absents.includes(jour);
+                const creneauxJour = p.dispo[jour] ?? [];
+                const chantierJour = p.jours.includes(jour);
+                return (
+                  <div
+                    key={p.id}
+                    className={`relative border-l border-leaf-100 ${absent ? "bg-gray-100" : ""}`}
+                    style={{ height: heures.length * PX_HEURE }}
+                  >
+                    {heures.map((h, i) => (
+                      <span
+                        key={h}
+                        className="absolute inset-x-0 border-t border-leaf-100/70"
+                        style={{ top: i * PX_HEURE }}
+                      />
+                    ))}
+
+                    {/* Fond vert pâle : ce que le paysagiste a déclaré */}
+                    {!absent && chantierJour && (
+                      <span
+                        className="absolute inset-x-0 bg-leaf-100/60"
+                        style={{
+                          top: (8 - HEURE_DEBUT) * PX_HEURE,
+                          height: 10 * PX_HEURE,
+                        }}
+                      />
+                    )}
+                    {!absent &&
+                      creneauxJour.map((t) => {
+                        const [hh, mm] = t.split(":").map(Number);
+                        return (
+                          <span
+                            key={t}
+                            className="absolute inset-x-1 rounded bg-blue-100/70"
+                            style={{
+                              top: ((hh * 60 + mm) / 60 - HEURE_DEBUT) * PX_HEURE,
+                              height: PX_HEURE / 2 - 2,
+                            }}
+                          />
+                        );
+                      })}
+
+                    {absent && (
+                      <span className="absolute inset-x-0 top-1/2 -translate-y-1/2 text-center text-xs font-semibold text-gray-500">
+                        Absent
+                      </span>
+                    )}
+
+                    {/* Rendez-vous */}
+                    {(parPro[p.id] ?? []).map((b) => {
+                      const debut = Math.max(minutesParis(b.startAt), HEURE_DEBUT * 60);
+                      const fin = Math.min(
+                        Math.max(minutesParis(b.endAt), debut + 30),
+                        HEURE_FIN * 60
+                      );
+                      const hauteur = ((fin - debut) / 60) * PX_HEURE - 2;
+                      return (
+                        <div
+                          key={b.id}
+                          title={`${heureParis(b.startAt)} – ${heureParis(b.endAt)} · ${b.firstName} ${b.lastName} · ${b.address}, ${b.city} · ${b.phone}`}
+                          className={`absolute inset-x-1 overflow-hidden rounded-lg px-1.5 py-0.5 text-left text-[11px] font-semibold leading-tight text-white shadow-sm ${
+                            b.kind === "chantier" ? "bg-green-500" : "bg-blue-500"
+                          }`}
+                          style={{
+                            top: ((debut - HEURE_DEBUT * 60) / 60) * PX_HEURE + 1,
+                            height: hauteur,
+                          }}
+                        >
+                          <span className="block truncate">
+                            <span className="font-normal opacity-90">{heureParis(b.startAt)}</span>{" "}
+                            {b.firstName} {b.lastName}
+                          </span>
+                          {hauteur > 34 && (
+                            <span className="block truncate font-normal opacity-90">{b.city}</span>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/app/src/app/api/admin/equipe/creneaux/route.ts
+++ b/app/src/app/api/admin/equipe/creneaux/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from "next/server";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { getSettings } from "@/lib/settings";
+import { getAvailability } from "@/lib/availability";
+import { prosDevis } from "@/lib/assign";
+import { cpToLatLng, distanceKm } from "@/lib/geo";
+import { utcToParis } from "@/lib/dates";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+/**
+ * GET /api/admin/equipe/creneaux?cp=33000&n=5 — les prochains créneaux de
+ * visite réellement disponibles pour un client donné, avec le paysagiste qui
+ * les couvre. C'est la réponse au « je suis au téléphone, quand puis-je
+ * proposer ? » : le gérant n'ouvre plus chaque agenda un par un.
+ */
+export async function GET(req: NextRequest) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const cp = (req.nextUrl.searchParams.get("cp") ?? "").trim();
+  if (!/^\d{5}$/.test(cp)) {
+    return NextResponse.json({ error: "Indiquez le code postal du client." }, { status: 400 });
+  }
+  const combien = Math.min(20, Math.max(1, Number(req.nextUrl.searchParams.get("n")) || 6));
+
+  const settings = await getSettings();
+  // Mêmes créneaux que ceux proposés au client sur le site : une seule source
+  // de vérité, donc aucun risque de proposer un horaire qui serait refusé.
+  const jours = await getAvailability(settings, undefined, cp);
+  const pros = await prosDevis();
+  const posClient = cpToLatLng(cp);
+
+  const creneaux: {
+    startAt: string;
+    date: string;
+    heure: string;
+    pro: { id: string; name: string; phone: string; distance: number | null } | null;
+  }[] = [];
+
+  for (const jour of jours) {
+    for (const iso of jour.slots) {
+      if (creneaux.length >= combien) break;
+      const paris = utcToParis(new Date(iso));
+      // Quel paysagiste a déclaré ce créneau, et lequel est le plus proche ?
+      const candidats = pros
+        .filter((p) => (p.dispo[paris.date] ?? []).includes(paris.time))
+        .map((p) => {
+          const pos = cpToLatLng(p.basePostalCode);
+          const d = posClient && pos ? Math.round(distanceKm(posClient, pos) * 10) / 10 : null;
+          return { pro: p, distance: d };
+        })
+        .filter((c) => c.distance === null || c.distance <= c.pro.radiusKm)
+        .sort((a, b) => (a.distance ?? Infinity) - (b.distance ?? Infinity));
+      const gagnant = candidats[0];
+      creneaux.push({
+        startAt: iso,
+        date: paris.date,
+        heure: paris.time,
+        pro: gagnant
+          ? {
+              id: gagnant.pro.id,
+              name: gagnant.pro.name,
+              phone: gagnant.pro.phone,
+              distance: gagnant.distance,
+            }
+          : null, // créneau des horaires du gérant : la visite lui revient
+      });
+    }
+    if (creneaux.length >= combien) break;
+  }
+
+  return NextResponse.json({ cp, creneaux });
+}

--- a/app/src/app/api/admin/equipe/route.ts
+++ b/app/src/app/api/admin/equipe/route.ts
@@ -1,0 +1,77 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { parisTimeToUtc, addDaysStr, todayParis } from "@/lib/dates";
+import { parseDates, parseDispo } from "@/lib/proStatus";
+import { joursAbsents } from "@/lib/absences";
+import { agencesActives } from "@/lib/agences";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/admin/equipe?agence=…&du=…&au=… — l'agenda d'équipe d'un secteur :
+ * une colonne par paysagiste, avec ses rendez-vous, ses disponibilités
+ * déclarées et ses absences. C'est la vue à ouvrir quand un client est au
+ * téléphone.
+ */
+export async function GET(req: NextRequest) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const p = req.nextUrl.searchParams;
+  const agenceId = (p.get("agence") ?? "").trim();
+  const du = /^\d{4}-\d{2}-\d{2}$/.test(p.get("du") ?? "") ? p.get("du")! : todayParis();
+  const au = /^\d{4}-\d{2}-\d{2}$/.test(p.get("au") ?? "") ? p.get("au")! : du;
+
+  const agences = await agencesActives();
+  const pros = await prisma.pro.findMany({
+    where: agenceId ? { agenceId } : {},
+    orderBy: { name: "asc" },
+  });
+  const proIds = pros.map((x) => x.id);
+
+  const bookings = proIds.length
+    ? await prisma.booking.findMany({
+        where: {
+          proId: { in: proIds },
+          status: { not: "annule" },
+          startAt: { gte: parisTimeToUtc(du, "00:00"), lt: parisTimeToUtc(addDaysStr(au, 1), "00:00") },
+        },
+        orderBy: { startAt: "asc" },
+        select: {
+          id: true,
+          proId: true,
+          kind: true,
+          firstName: true,
+          lastName: true,
+          phone: true,
+          city: true,
+          address: true,
+          startAt: true,
+          endAt: true,
+        },
+      })
+    : [];
+
+  const absences = await joursAbsents(du, au);
+
+  return NextResponse.json({
+    du,
+    au,
+    agences: agences.map((a) => ({ id: a.id, nom: a.nom, couleur: a.couleur })),
+    pros: pros.map((pro) => ({
+      id: pro.id,
+      name: pro.name,
+      phone: pro.phone,
+      baseCity: pro.baseCity,
+      basePostalCode: pro.basePostalCode,
+      radiusKm: pro.radiusKm,
+      agenceId: pro.agenceId,
+      // Ce qu'il a déclaré : jours de chantier, créneaux de visite, absences.
+      jours: parseDates(pro.datesJson),
+      dispo: parseDispo(pro.devisDispoJson),
+      absents: Array.from(absences.get(pro.id) ?? []),
+    })),
+    bookings,
+  });
+}

--- a/app/src/app/api/pro/absences/route.ts
+++ b/app/src/app/api/pro/absences/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { currentProId } from "@/lib/proAuth";
+import { MOTIFS_ABSENCE, absencesDe, validerIntervalle } from "@/lib/absences";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/pro/absences — mes congés et indisponibilités déclarés. */
+export async function GET() {
+  const proId = currentProId();
+  if (!proId) return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  return NextResponse.json({ absences: await absencesDe(proId) });
+}
+
+/** POST /api/pro/absences { du, au, motif, note } — déclarer une absence. */
+export async function POST(req: NextRequest) {
+  const proId = currentProId();
+  if (!proId) return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+  const du = String(body.du ?? "").trim();
+  const au = String(body.au ?? du).trim();
+  const erreur = validerIntervalle(du, au);
+  if (erreur) return NextResponse.json({ error: erreur }, { status: 400 });
+
+  const motif = MOTIFS_ABSENCE[String(body.motif)] ? String(body.motif) : "conges";
+  const absence = await prisma.absence.create({
+    data: { proId, du, au, motif, note: String(body.note ?? "").slice(0, 300) },
+  });
+  return NextResponse.json({ ok: true, absence, absences: await absencesDe(proId) }, { status: 201 });
+}
+
+/** DELETE /api/pro/absences?id=… — retirer une absence. */
+export async function DELETE(req: NextRequest) {
+  const proId = currentProId();
+  if (!proId) return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  const id = req.nextUrl.searchParams.get("id") ?? "";
+  const absence = await prisma.absence.findUnique({ where: { id } });
+  if (!absence || absence.proId !== proId) {
+    return NextResponse.json({ error: "introuvable" }, { status: 404 });
+  }
+  await prisma.absence.delete({ where: { id } });
+  return NextResponse.json({ ok: true, absences: await absencesDe(proId) });
+}

--- a/app/src/app/pro/disponibilites/Absences.tsx
+++ b/app/src/app/pro/disponibilites/Absences.tsx
@@ -1,0 +1,167 @@
+"use client";
+
+// Congés et indisponibilités du paysagiste. Une absence déclarée bloque
+// l'attribution automatique et apparaît dans l'agenda du gérant — contrairement
+// à un jour simplement non coché.
+import { useEffect, useState } from "react";
+
+const MOTIFS: Record<string, string> = {
+  conges: "Congés",
+  arret: "Arrêt de travail",
+  formation: "Formation",
+  personnel: "Personnel",
+};
+
+type Absence = { id: string; du: string; au: string; motif: string; note: string };
+
+function jourFr(j: string): string {
+  return new Date(`${j}T12:00:00`).toLocaleDateString("fr-FR", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+  });
+}
+
+export default function Absences() {
+  const [absences, setAbsences] = useState<Absence[]>([]);
+  const [ouvert, setOuvert] = useState(false);
+  const [du, setDu] = useState("");
+  const [au, setAu] = useState("");
+  const [motif, setMotif] = useState("conges");
+  const [erreur, setErreur] = useState("");
+
+  useEffect(() => {
+    fetch("/api/pro/absences")
+      .then((r) => (r.ok ? r.json() : { absences: [] }))
+      .then((d) => setAbsences(d.absences ?? []))
+      .catch(() => {});
+  }, []);
+
+  async function ajouter() {
+    setErreur("");
+    const res = await fetch("/api/pro/absences", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ du, au: au || du, motif }),
+    });
+    const d = await res.json();
+    if (!res.ok) {
+      setErreur(d.error ?? "Enregistrement impossible.");
+      return;
+    }
+    setAbsences(d.absences ?? []);
+    setOuvert(false);
+    setDu("");
+    setAu("");
+  }
+
+  async function retirer(a: Absence) {
+    if (!window.confirm(`Retirer l'absence du ${jourFr(a.du)} au ${jourFr(a.au)} ?`)) return;
+    const res = await fetch(`/api/pro/absences?id=${a.id}`, { method: "DELETE" });
+    if (res.ok) {
+      const d = await res.json();
+      setAbsences(d.absences ?? []);
+    }
+  }
+
+  const aujourdhui = new Date().toISOString().slice(0, 10);
+  const aVenir = absences.filter((a) => a.au >= aujourdhui);
+
+  return (
+    <section className="card mt-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h2 className="font-bold">Congés et absences</h2>
+        {!ouvert && (
+          <button className="btn-secondary !px-3 !py-1.5 text-sm" onClick={() => setOuvert(true)}>
+            Déclarer
+          </button>
+        )}
+      </div>
+      <p className="text-sm text-leaf-800/70">
+        Une absence déclarée bloque toute attribution sur la période, même les jours que vous
+        aviez cochés. Le gérant la voit dans son agenda.
+      </p>
+
+      {ouvert && (
+        <div className="rounded-xl border-2 border-leaf-300 bg-leaf-50/40 p-3">
+          <div className="grid gap-2 sm:grid-cols-3">
+            <label className="text-xs text-leaf-800/60">
+              Du
+              <input
+                className="input !py-1.5"
+                type="date"
+                value={du}
+                onChange={(e) => setDu(e.target.value)}
+              />
+            </label>
+            <label className="text-xs text-leaf-800/60">
+              Au
+              <input
+                className="input !py-1.5"
+                type="date"
+                value={au}
+                onChange={(e) => setAu(e.target.value)}
+              />
+            </label>
+            <label className="text-xs text-leaf-800/60">
+              Motif
+              <select
+                className="input !py-1.5"
+                value={motif}
+                onChange={(e) => setMotif(e.target.value)}
+              >
+                {Object.entries(MOTIFS).map(([id, label]) => (
+                  <option key={id} value={id}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+          {erreur && <p className="mt-2 text-sm font-semibold text-red-600">{erreur}</p>}
+          <div className="mt-3 flex gap-2">
+            <button
+              className="btn-primary !w-auto !px-4 !py-2 text-sm"
+              onClick={ajouter}
+              disabled={!du}
+            >
+              Enregistrer
+            </button>
+            <button
+              className="btn-secondary !px-4 !py-2 text-sm"
+              onClick={() => {
+                setOuvert(false);
+                setErreur("");
+              }}
+            >
+              Annuler
+            </button>
+          </div>
+        </div>
+      )}
+
+      {aVenir.length === 0 ? (
+        <p className="text-sm text-leaf-800/50">Aucune absence déclarée.</p>
+      ) : (
+        <ul className="space-y-1">
+          {aVenir.map((a) => (
+            <li
+              key={a.id}
+              className="flex flex-wrap items-center gap-2 rounded-xl bg-sand-50 px-3 py-2 text-sm"
+            >
+              <span className="font-semibold">
+                {a.du === a.au ? jourFr(a.du) : `Du ${jourFr(a.du)} au ${jourFr(a.au)}`}
+              </span>
+              <span className="rounded-full bg-white px-2 py-0.5 text-xs font-semibold text-leaf-800/70">
+                {MOTIFS[a.motif] ?? a.motif}
+              </span>
+              <button onClick={() => retirer(a)} className="ml-auto text-xs text-red-600 underline">
+                Retirer
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/app/src/app/pro/disponibilites/page.tsx
+++ b/app/src/app/pro/disponibilites/page.tsx
@@ -9,6 +9,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { MODE_META, MODE_ORDER, modeOf, statusOfMode, type ProMode } from "@/lib/proStatus";
 import { ymd } from "../shared";
+import Absences from "./Absences";
 
 type Pro = {
   name: string;
@@ -335,6 +336,8 @@ export default function ProDisponibilitesPage() {
             </div>
           )}
       </section>
+
+      <Absences />
     </main>
   );
 }

--- a/app/src/lib/absences.ts
+++ b/app/src/lib/absences.ts
@@ -1,0 +1,57 @@
+// Absences des professionnels. Une absence est une déclaration explicite
+// (« je suis en congés du 1er au 15 ») : elle bloque l'attribution automatique
+// et s'affiche dans les agendas, contrairement à un jour non coché qu'on ne
+// peut pas distinguer d'un planning pas encore rempli.
+import type { Absence } from "@prisma/client";
+import { prisma } from "./prisma";
+
+export const MOTIFS_ABSENCE: Record<string, string> = {
+  conges: "Congés",
+  arret: "Arrêt de travail",
+  formation: "Formation",
+  personnel: "Personnel",
+};
+
+export function estDansAbsence(a: { du: string; au: string }, jour: string): boolean {
+  return jour >= a.du && jour <= a.au;
+}
+
+/** Jours absents par pro, sur une fenêtre donnée : proId → Set de AAAA-MM-JJ. */
+export async function joursAbsents(
+  du: string,
+  au: string
+): Promise<Map<string, Set<string>>> {
+  const absences = await prisma.absence.findMany({
+    where: { du: { lte: au }, au: { gte: du } },
+  });
+  const map = new Map<string, Set<string>>();
+  for (const a of absences) {
+    if (!map.has(a.proId)) map.set(a.proId, new Set());
+    const set = map.get(a.proId)!;
+    // On n'énumère que les jours de la fenêtre demandée.
+    const debut = a.du > du ? a.du : du;
+    const fin = a.au < au ? a.au : au;
+    const d = new Date(`${debut}T12:00:00Z`);
+    const f = new Date(`${fin}T12:00:00Z`);
+    while (d <= f) {
+      set.add(d.toISOString().slice(0, 10));
+      d.setUTCDate(d.getUTCDate() + 1);
+    }
+  }
+  return map;
+}
+
+/** Absences d'un pro, les plus récentes d'abord. */
+export async function absencesDe(proId: string): Promise<Absence[]> {
+  return prisma.absence.findMany({ where: { proId }, orderBy: { du: "desc" } });
+}
+
+/** Valide un intervalle saisi par le pro ou le gérant. */
+export function validerIntervalle(du: string, au: string): string | null {
+  const format = /^\d{4}-\d{2}-\d{2}$/;
+  if (!format.test(du) || !format.test(au)) return "Dates invalides.";
+  if (au < du) return "La date de fin est avant la date de début.";
+  const jours = (new Date(`${au}T00:00:00Z`).getTime() - new Date(`${du}T00:00:00Z`).getTime()) / 86400000;
+  if (jours > 366) return "Une absence ne peut pas dépasser un an.";
+  return null;
+}

--- a/app/src/lib/assign.ts
+++ b/app/src/lib/assign.ts
@@ -12,6 +12,7 @@ import { prisma } from "./prisma";
 import { cpToLatLng, distanceKm } from "./geo";
 import { utcToParis } from "./dates";
 import { parseDates, parseDispo } from "./proStatus";
+import { joursAbsents } from "./absences";
 
 export { parseDispo };
 
@@ -86,9 +87,18 @@ async function chargeSemaine(day: string): Promise<Map<string, number>> {
  * Tous les pros, avec les jours de chantier qu'ils ont cochés. Ne rien cocher
  * = ne rien recevoir : c'est la seule façon de se déclarer indisponible.
  */
-export async function prosChantier(): Promise<(Pro & { jours: string[] })[]> {
+export async function prosChantier(): Promise<(Pro & { jours: string[]; absents: Set<string> })[]> {
   const pros = await prisma.pro.findMany();
-  return pros.map((p) => Object.assign(p, { jours: parseDates(p.datesJson) }));
+  const tousJours = pros.flatMap((p) => parseDates(p.datesJson)).sort();
+  const absences = tousJours.length
+    ? await joursAbsents(tousJours[0], tousJours[tousJours.length - 1])
+    : new Map<string, Set<string>>();
+  return pros.map((p) =>
+    Object.assign(p, {
+      jours: parseDates(p.datesJson),
+      absents: absences.get(p.id) ?? new Set<string>(),
+    })
+  );
 }
 
 /**
@@ -96,7 +106,7 @@ export async function prosChantier(): Promise<(Pro & { jours: string[] })[]> {
  * `busy` : jours déjà pris par pro (précalculé) ; `exclude` : pros écartés (désistés).
  */
 export function rankCandidates(
-  pros: (Pro & { jours: string[] })[],
+  pros: (Pro & { jours: string[]; absents?: Set<string> })[],
   day: string,
   clientCp: string,
   busy: Map<string, Set<string>>,
@@ -111,6 +121,8 @@ export function rankCandidates(
     if (clientPos && proPos) c.distance = Math.round(distanceKm(clientPos, proPos) * 10) / 10;
     if (exclude.includes(pro.id)) {
       c.raison = "s'est désisté";
+    } else if (pro.absents?.has(day)) {
+      c.raison = "absent (congés ou indisponibilité déclarée)";
     } else if (!pro.jours.includes(day)) {
       c.raison = "pas disponible ce jour";
     } else if (busy.get(pro.id)?.has(day)) {
@@ -201,7 +213,17 @@ export async function assignChantiers(
 /** Tous les pros, avec les créneaux de visite qu'ils ont déclarés jour par jour. */
 export async function prosDevis(): Promise<(Pro & { dispo: Record<string, string[]> })[]> {
   const pros = await prisma.pro.findMany();
-  return pros.map((p) => Object.assign(p, { dispo: parseDispo(p.devisDispoJson) }));
+  const jours = pros.flatMap((p) => Object.keys(parseDispo(p.devisDispoJson))).sort();
+  const absences = jours.length
+    ? await joursAbsents(jours[0], jours[jours.length - 1])
+    : new Map<string, Set<string>>();
+  return pros.map((p) => {
+    const absents = absences.get(p.id);
+    const dispo = parseDispo(p.devisDispoJson);
+    // Une visite ne peut pas être proposée un jour d'absence déclarée.
+    if (absents) for (const j of Array.from(absents)) delete dispo[j];
+    return Object.assign(p, { dispo });
+  });
 }
 
 /** Visites devis déjà attribuées, par pro : Set de « AAAA-MM-JJ HH:mm ». */
@@ -330,6 +352,7 @@ export async function joursAvecCapacite(
   for (const day of tousJours) {
     for (const pro of pros) {
       if (!pro.jours.includes(day)) continue;
+      if (pro.absents.has(day)) continue;
       if (busy.get(pro.id)?.has(day)) continue;
       if (clientPos) {
         const proPos = cpToLatLng(pro.basePostalCode);

--- a/app/src/lib/availability.ts
+++ b/app/src/lib/availability.ts
@@ -6,6 +6,21 @@ import { getBusyPeriods } from "./google";
 import { parseOpeningHours, parseChantierHours, parseDaysOff } from "./settings";
 import { parisTimeToUtc, utcToParis, addDaysStr, todayParis } from "./dates";
 import { joursAvecCapacite, creneauxDevisPros } from "./assign";
+import { agencesActives, couvertureDe } from "./agences";
+
+/**
+ * Le gérant fait lui-même les visites, mais depuis SON secteur. Dès que
+ * plusieurs secteurs existent, ses horaires ne doivent plus être proposés à un
+ * client d'une autre ville — sinon on promet une visite à 350 km.
+ */
+async function gerantCouvre(settings: Settings, clientCp?: string): Promise<boolean> {
+  if (!clientCp) return true;
+  const agences = await agencesActives();
+  if (agences.length === 0) return true; // zone unique : comportement historique
+  const sienne = agences.find((a) => couvertureDe(a, settings.basePostalCode).raison !== null);
+  if (!sienne) return true; // gérant hors secteurs : on ne le bride pas
+  return couvertureDe(sienne, clientCp).raison !== null;
+}
 
 export type DaySlots = { date: string; slots: string[] }; // slots = ISO UTC des débuts
 export type BookingKind = "devis" | "chantier";
@@ -70,9 +85,10 @@ export async function getAvailability(
   const rangeEnd = parisTimeToUtc(addDaysStr(startDay, settings.maxDaysAhead), "23:59");
   // Créneaux du gérant (horaires d'ouverture, agenda Google) ∪ créneaux déclarés
   // par les pros (jour par jour, trous en journée compris) : option B du client.
-  const [busy, prosSlots] = await Promise.all([
+  const [busy, prosSlots, gerantDispo] = await Promise.all([
     getBusy(settings, rangeStart, rangeEnd, excludeBookingId),
     creneauxDevisPros(clientCp, excludeBookingId),
+    gerantCouvre(settings, clientCp),
   ]);
 
   const minStart = new Date(Date.now() + settings.minNoticeHours * 3600_000);
@@ -84,7 +100,7 @@ export async function getAvailability(
     const rawConfig = openingHours[String(weekday)];
     const hasProSlots = (prosSlots.get(dateStr)?.size ?? 0) > 0;
     // Jour fermé côté gérant : reste proposé si un pro a déclaré des créneaux.
-    if (!rawConfig?.enabled && !hasProSlots) continue;
+    if ((!rawConfig?.enabled || !gerantDispo) && !hasProSlots) continue;
     if (daysOff.some((d) => dateStr >= d.from && dateStr <= d.to)) continue;
     const dayConfig = rawConfig?.enabled ? rawConfig : { enabled: false, start: "00:00", end: "00:00" };
 
@@ -93,8 +109,9 @@ export async function getAvailability(
     const slots = new Set<string>();
 
     // 1. Créneaux du gérant : horaires d'ouverture, moins l'agenda occupé.
+    //    Ignorés si le client est dans un secteur que le gérant ne couvre pas.
     for (
-      let t = dayStart.getTime();
+      let t = gerantDispo ? dayStart.getTime() : dayEnd.getTime();
       t + duration * 60_000 <= dayEnd.getTime();
       t += step * 60_000
     ) {


### PR DESCRIPTION
Dernière phase du plan CRM : les agendas à deux niveaux.

## Ce qui change

- **Modèle `Absence`** (du / au / motif). Contrairement à un jour non coché — qu'on ne peut pas distinguer d'un planning pas encore rempli — une absence déclarée **bloque l'attribution automatique** et s'affiche dans tous les agendas. Le paysagiste la déclare depuis sa page « Mes disponibilités ».
- **Agenda d'équipe** (`/admin/equipe`) : une colonne par paysagiste, vue Jour, sélecteur de secteur mémorisé d'une visite à l'autre, disponibilités déclarées en fond vert pâle, absences grisées, rendez-vous en bleu (visite) et vert (chantier).
- **Bouton « Premiers créneaux libres »** : on saisit le code postal du client au téléphone, l'application propose les prochains créneaux **avec le paysagiste qui les couvre et sa distance**. Il s'appuie sur le moteur qui sert déjà le tunnel de réservation — impossible de proposer un horaire qui serait ensuite refusé.

## Correction importante trouvée au test

Avec deux secteurs, les horaires personnels du gérant (Saint-Chinian) étaient proposés à un client **bordelais, à 348 km**. Ses créneaux ne valent désormais que pour le secteur où se trouve son adresse de base ; les autres secteurs reposent sur leur équipe locale.

## Tests effectués (PostgreSQL local)

Jeu d'essai : 2 secteurs, 4 paysagistes (2 par ville), dont **un en congés**, et un rendez-vous déjà pris.

| Vérification | Résultat |
| --- | --- |
| Client de Bordeaux | uniquement Julien (Bordeaux) — plus aucun créneau du gérant |
| Créneau de 11h déclaré par le seul paysagiste en congés | **absent des propositions** |
| Client de Béziers | équipe locale + créneaux du gérant, comme avant |
| Filtre secteur | 4 colonnes → 2 colonnes pour Bordeaux |
| Paysagiste en congés | colonne grisée, mention « Absent » |
| Secteur choisi | mémorisé après rechargement |

`npm run build` OK.

## Le plan CRM est terminé

Phases 0 à 3 livrées : secteurs multi-villes, base « Tous les clients », espace « Affaires » avec pipeline, agendas individuels et d'équipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_