### PR TITLE
Clients : barre d'outils allégée, reprise déplacée dans les paramètres

### DIFF
--- a/app/src/app/admin/clients/page.tsx
+++ b/app/src/app/admin/clients/page.tsx
@@ -4,7 +4,6 @@
 // donné lieu à un rendez-vous ou non. Tuiles de synthèse puis tableau ; une
 // ligne s'ouvre sur la fiche complète (coordonnées, RDV, journal des échanges).
 import { Fragment, useEffect, useState } from "react";
-import { ORIGINES } from "@/lib/contactLabels";
 import FicheContact from "./FicheContact";
 
 export type Contact = {
@@ -119,12 +118,9 @@ export default function AdminClientsPage() {
   const [tronque, setTronque] = useState(false);
   const [chargement, setChargement] = useState(true);
   const [q, setQ] = useState("");
-  const [origine, setOrigine] = useState("");
   const [agence, setAgence] = useState("");
   const [ouvert, setOuvert] = useState<string | null>(null);
   const [nouveau, setNouveau] = useState(false);
-  const [reprise, setReprise] = useState("");
-  const [repriseEnCours, setRepriseEnCours] = useState(false);
   const [brouillon, setBrouillon] = useState({
     firstName: "",
     lastName: "",
@@ -138,7 +134,6 @@ export default function AdminClientsPage() {
   function charger() {
     const p = new URLSearchParams();
     if (q.trim()) p.set("q", q.trim());
-    if (origine) p.set("origine", origine);
     if (agence) p.set("agence", agence);
     fetch(`/api/admin/contacts?${p.toString()}`)
       .then((r) => {
@@ -168,23 +163,7 @@ export default function AdminClientsPage() {
     const t = setTimeout(charger, 300);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [q, origine, agence]);
-
-  async function lancerReprise() {
-    if (
-      !window.confirm(
-        "Reprendre les rendez-vous, prospects et comptes existants pour remplir la base clients ?\nL'opération peut être relancée sans risque : elle ne crée pas de doublon."
-      )
-    )
-      return;
-    setRepriseEnCours(true);
-    setReprise("");
-    const res = await fetch("/api/admin/contacts/reprise", { method: "POST" });
-    const d = await res.json();
-    setRepriseEnCours(false);
-    setReprise(d.message ?? d.error ?? "Reprise impossible.");
-    charger();
-  }
+  }, [q, agence]);
 
   async function creer() {
     const res = await fetch("/api/admin/contacts", {
@@ -219,10 +198,6 @@ export default function AdminClientsPage() {
         <Tuile label="CA généré" valeur={euros(stats.caTotal)} couleur="#347030" icone={ICONES.ca} />
       </div>
 
-      {reprise && (
-        <p className="mb-3 rounded-xl bg-leaf-50 px-4 py-3 text-sm font-medium text-leaf-800">{reprise}</p>
-      )}
-
       <div className="mb-4 flex flex-wrap items-center gap-2">
         <input
           className="input flex-1 !w-auto"
@@ -230,14 +205,6 @@ export default function AdminClientsPage() {
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />
-        <select className="input !w-auto" value={origine} onChange={(e) => setOrigine(e.target.value)}>
-          <option value="">Toutes origines</option>
-          {Object.entries(ORIGINES).map(([id, label]) => (
-            <option key={id} value={id}>
-              {label}
-            </option>
-          ))}
-        </select>
         {agences.length > 0 && (
           <select className="input !w-auto" value={agence} onChange={(e) => setAgence(e.target.value)}>
             <option value="">Tous secteurs</option>
@@ -248,9 +215,6 @@ export default function AdminClientsPage() {
             ))}
           </select>
         )}
-        <button className="btn-secondary !px-3 !py-2.5 text-sm" onClick={lancerReprise} disabled={repriseEnCours}>
-          {repriseEnCours ? "Reprise…" : "Reprendre l'existant"}
-        </button>
         <button className="btn-primary !w-auto !px-4 !py-2.5 text-sm" onClick={() => setNouveau(true)}>
           + Nouveau client
         </button>
@@ -307,12 +271,13 @@ export default function AdminClientsPage() {
 
       {!chargement && contacts.length === 0 && (
         <div className="card py-8 text-center text-sm text-leaf-800/60">
-          {q || origine || agence ? (
+          {q || agence ? (
             "Aucun client ne correspond."
           ) : (
             <>
-              La base est vide. Si vous aviez déjà des rendez-vous et des prospects, cliquez sur
-              <b> Reprendre l&apos;existant</b> : ils seront regroupés en fiches clients.
+              La base est vide. Si vous aviez déjà des rendez-vous et des prospects, lancez la
+              reprise depuis <b>Paramètres → Reprise des données</b> : ils seront regroupés en
+              fiches clients.
             </>
           )}
         </div>

--- a/app/src/app/admin/parametres/RepriseSection.tsx
+++ b/app/src/app/admin/parametres/RepriseSection.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+// Reprise des données : deux opérations à faire une seule fois, au démarrage.
+// Elles vivent ici plutôt que dans les écrans de travail quotidiens, qu'elles
+// encombraient. Relançables sans risque : elles ne créent aucun doublon.
+import { useState } from "react";
+
+export default function RepriseSection() {
+  const [messages, setMessages] = useState<Record<string, string>>({});
+  const [enCours, setEnCours] = useState("");
+
+  async function lancer(cle: string, url: string, question: string) {
+    if (!window.confirm(`${question}\n\nL'opération peut être relancée sans risque : elle ne crée pas de doublon.`))
+      return;
+    setEnCours(cle);
+    setMessages((m) => ({ ...m, [cle]: "" }));
+    const res = await fetch(url, { method: "POST" });
+    const d = await res.json().catch(() => ({}));
+    setEnCours("");
+    setMessages((m) => ({ ...m, [cle]: d.message ?? d.error ?? "Reprise impossible." }));
+  }
+
+  return (
+    <section className="card space-y-3">
+      <h2 className="font-bold">Reprise des données</h2>
+      <p className="text-sm text-leaf-800/70">
+        À lancer une fois, au démarrage : vos rendez-vous, prospects et comptes déjà enregistrés
+        sont regroupés en fiches clients, puis en affaires. Dans cet ordre.
+      </p>
+
+      <div className="grid gap-2 sm:grid-cols-2">
+        <div>
+          <button
+            className="btn-secondary w-full !py-2.5 text-sm"
+            disabled={enCours !== ""}
+            onClick={() =>
+              lancer(
+                "clients",
+                "/api/admin/contacts/reprise",
+                "1. Remplir la base « Tous les clients » à partir des rendez-vous, prospects et comptes existants ?"
+              )
+            }
+          >
+            {enCours === "clients" ? "Reprise…" : "1. Remplir la base clients"}
+          </button>
+          {messages.clients && (
+            <p className="mt-2 rounded-xl bg-leaf-50 px-3 py-2 text-sm text-leaf-800">{messages.clients}</p>
+          )}
+        </div>
+
+        <div>
+          <button
+            className="btn-secondary w-full !py-2.5 text-sm"
+            disabled={enCours !== ""}
+            onClick={() =>
+              lancer(
+                "affaires",
+                "/api/admin/affaires/reprise",
+                "2. Créer les affaires à partir des rendez-vous existants ?"
+              )
+            }
+          >
+            {enCours === "affaires" ? "Reprise…" : "2. Créer les affaires"}
+          </button>
+          {messages.affaires && (
+            <p className="mt-2 rounded-xl bg-leaf-50 px-3 py-2 text-sm text-leaf-800">{messages.affaires}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/src/app/admin/parametres/page.tsx
+++ b/app/src/app/admin/parametres/page.tsx
@@ -4,6 +4,7 @@
 import { useEffect, useRef, useState } from "react";
 import PhotoUpload from "@/components/PhotoUpload";
 import AgencesSection from "./AgencesSection";
+import RepriseSection from "./RepriseSection";
 
 /** Redimensionne le logo côté client (max 600 px de large, PNG). */
 async function fileToLogoDataUrl(file: File): Promise<string> {
@@ -308,6 +309,8 @@ export default function AdminSettingsPage() {
         </section>
 
         <AgencesSection />
+
+        <RepriseSection />
 
         {/* Zone d'intervention (repli si aucun secteur) */}
         <section className="card space-y-3">


### PR DESCRIPTION
Les deux contrôles pointés par le client disparaissent de l'écran Clients.

- **Filtre « Toutes origines » supprimé** : la recherche couvre le besoin.
- **« Reprendre l'existant » déplacé, pas supprimé** — ce n'est pas une action du quotidien. Il rejoint une section **« Reprise des données »** dans les paramètres, avec les deux imports numérotés dans l'ordre où ils doivent être lancés (1. base clients, 2. affaires).

Il ne reste donc sur Clients que la recherche, le filtre de secteur et « + Nouveau client ». Le message d'état vide renvoie vers le bon endroit.

## Tests effectués (PostgreSQL local)

| Vérification | Résultat |
| --- | --- |
| Sélecteur d'origine sur Clients | absent |
| Bouton « Reprendre l'existant » sur Clients | absent |
| Reprise étape 1 depuis les paramètres | 3 fiches créées, 4 RDV rattachés |
| Reprise étape 2 depuis les paramètres | 2 affaires créées |
| Retour sur Clients | les clients repris s'affichent |

`npm run build` OK.

## Note

L'écran **Affaires** garde son propre bouton « Reprendre l'existant ». Dites-moi si vous voulez qu'il parte aussi vers les paramètres, pour la cohérence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_