### PR TITLE
Page Chantiers : rapports d'intervention avant / après

### DIFF
--- a/app/src/app/admin/AdminNav.tsx
+++ b/app/src/app/admin/AdminNav.tsx
@@ -83,6 +83,13 @@ const ICONS: Record<string, JSX.Element> = {
       <path d="M3 10h18M9 16l2 2 4-4" />
     </svg>
   ),
+  chantiers: (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5 shrink-0">
+      <path d="M9 3h6a1 1 0 0 1 1 1v2H8V4a1 1 0 0 1 1-1z" />
+      <path d="M16 5h2a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2" />
+      <path d="m9 13 2 2 4-4" />
+    </svg>
+  ),
   logout: (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5 shrink-0">
       <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4" />
@@ -98,6 +105,7 @@ const LINKS = [
   { href: "/admin/affaires", label: "Affaires", icon: "affaires" },
   { href: "/admin/planning", label: "Agenda", icon: "agenda" },
   { href: "/admin/equipe", label: "Agenda d'équipe", icon: "equipe" },
+  { href: "/admin/chantiers", label: "Chantiers", icon: "chantiers" },
   { href: "/admin/terrain", label: "Gestion terrain", icon: "terrain" },
   { href: "/admin/stats", label: "Statistiques", icon: "stats" },
   { href: "/admin/meta", label: "Publicités Meta", icon: "meta" },

--- a/app/src/app/admin/chantiers/page.tsx
+++ b/app/src/app/admin/chantiers/page.tsx
@@ -1,0 +1,288 @@
+"use client";
+
+// Chantiers : les rapports d'intervention avant / après remplis par les
+// paysagistes depuis leur pointage. Une carte = une journée sur un chantier.
+import { useEffect, useState } from "react";
+
+type Rapport = {
+  id: string;
+  date: string;
+  validated: boolean;
+  pro: { id: string; name: string } | null;
+  avant: string[];
+  apres: string[];
+  booking: {
+    id: string;
+    contactId: string | null;
+    firstName: string;
+    lastName: string;
+    city: string;
+    address: string;
+    projectType: string;
+  } | null;
+};
+type ClientLite = { id: string; firstName: string; lastName: string };
+
+const PRESTATIONS: Record<string, string> = {
+  entretien: "Entretien de jardin",
+  taille_haie: "Taille de haie",
+  debroussaillage: "Débroussaillage",
+  contrat_annuel: "Contrat d'entretien",
+  autre: "Autre projet",
+};
+
+function jourFr(d: string): string {
+  return new Date(`${d}T12:00:00`).toLocaleDateString("fr-FR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  });
+}
+
+/** Vignettes avant / après côte à côte : c'est le cœur du rapport. */
+function Duo({ avant, apres }: { avant: string[]; apres: string[] }) {
+  const [agrandie, setAgrandie] = useState<string | null>(null);
+  const bloc = (titre: string, liste: string[]) => (
+    <div className="min-w-0 flex-1">
+      <p className="mb-1 text-[11px] font-semibold uppercase tracking-wider text-leaf-800/50">
+        {titre}
+      </p>
+      {liste.length === 0 ? (
+        <div className="flex h-24 items-center justify-center rounded-lg border border-dashed border-leaf-200 text-xs text-leaf-800/40">
+          aucune photo
+        </div>
+      ) : (
+        <div className="flex gap-1">
+          {liste.slice(0, 2).map((p, i) => (
+            <button
+              key={i}
+              onClick={() => setAgrandie(p)}
+              className="relative h-24 min-w-0 flex-1 overflow-hidden rounded-lg"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={p} alt={`${titre} ${i + 1}`} className="h-full w-full object-cover" />
+              {i === 1 && liste.length > 2 && (
+                <span className="absolute inset-0 flex items-center justify-center bg-black/50 text-xs font-bold text-white">
+                  +{liste.length - 2}
+                </span>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+  return (
+    <>
+      <div className="flex gap-2">
+        {bloc("Avant", avant)}
+        {bloc("Après", apres)}
+      </div>
+      {agrandie && (
+        <button
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/80 p-4"
+          onClick={() => setAgrandie(null)}
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={agrandie} alt="Photo du chantier" className="max-h-full max-w-full rounded-xl" />
+        </button>
+      )}
+    </>
+  );
+}
+
+export default function AdminChantiersPage() {
+  const [rapports, setRapports] = useState<Rapport[]>([]);
+  const [clients, setClients] = useState<ClientLite[]>([]);
+  const [compteurs, setCompteurs] = useState({ enCours: 0, termines: 0, total: 0 });
+  const [etat, setEtat] = useState<"en_cours" | "termines">("en_cours");
+  const [client, setClient] = useState("");
+  const [chargement, setChargement] = useState(true);
+  const [erreur, setErreur] = useState("");
+  const [vitrine, setVitrine] = useState<string[]>([]);
+
+  function charger() {
+    const p = new URLSearchParams({ etat });
+    if (client) p.set("client", client);
+    fetch(`/api/admin/chantiers?${p.toString()}`)
+      .then((r) => {
+        if (r.status === 401) {
+          window.location.href = "/admin/login";
+          throw new Error("unauthorized");
+        }
+        return r.json();
+      })
+      .then((d) => {
+        setRapports(d.rapports ?? []);
+        setClients(d.clients ?? []);
+        setCompteurs(d.compteurs ?? { enCours: 0, termines: 0, total: 0 });
+      })
+      .catch(() => {})
+      .finally(() => setChargement(false));
+    fetch("/api/admin/gallery")
+      .then((r) => (r.ok ? r.json() : { photos: [] }))
+      .then((d) => setVitrine(d.photos ?? []))
+      .catch(() => {});
+  }
+
+  useEffect(() => {
+    setChargement(true);
+    charger();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [etat, client]);
+
+  async function agir(id: string, patch: Record<string, unknown>) {
+    setErreur("");
+    const res = await fetch(`/api/admin/chantiers/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    });
+    if (!res.ok) {
+      const d = await res.json().catch(() => ({}));
+      setErreur(d.error ?? "Action impossible.");
+      return;
+    }
+    charger();
+  }
+
+  async function supprimer(r: Rapport) {
+    if (
+      !window.confirm(
+        "Supprimer les photos de ce rapport ?\n\nLes heures pointées de la journée sont conservées : elles servent à la paie."
+      )
+    )
+      return;
+    const res = await fetch(`/api/admin/chantiers/${r.id}`, { method: "DELETE" });
+    if (res.ok) charger();
+  }
+
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-6">
+      <h1 className="text-2xl font-bold">Chantiers</h1>
+      <p className="mb-5 text-sm text-leaf-800/60">Rapports d&apos;intervention avant / après</p>
+
+      <div className="mb-4 flex flex-wrap items-center justify-between gap-2">
+        <div className="flex rounded-xl bg-leaf-50 p-1">
+          {(
+            [
+              ["en_cours", `En cours (${compteurs.enCours})`],
+              ["termines", `Terminés (${compteurs.termines})`],
+            ] as const
+          ).map(([id, label]) => (
+            <button
+              key={id}
+              onClick={() => setEtat(id)}
+              className={`rounded-lg px-4 py-1.5 text-sm font-semibold transition ${
+                etat === id ? "bg-white text-leaf-800 shadow-sm" : "text-leaf-800/60"
+              }`}
+            >
+              {label}
+            </button>
+          ))}
+        </div>
+        {clients.length > 0 && (
+          <select className="input !w-auto" value={client} onChange={(e) => setClient(e.target.value)}>
+            <option value="">Tous les clients</option>
+            {clients.map((c) => (
+              <option key={c.id} value={c.id}>
+                {`${c.firstName} ${c.lastName}`.trim() || "Sans nom"}
+              </option>
+            ))}
+          </select>
+        )}
+      </div>
+
+      {erreur && <p className="mb-3 rounded-xl bg-red-50 px-4 py-3 text-sm font-semibold text-red-700">{erreur}</p>}
+
+      {chargement && <p className="py-8 text-center text-leaf-800/60">Chargement…</p>}
+
+      {!chargement && rapports.length === 0 && (
+        <div className="card py-8 text-center text-sm text-leaf-800/60">
+          {compteurs.total === 0 ? (
+            <>
+              Aucun rapport pour l&apos;instant. Vos paysagistes en créent un en ajoutant des photos
+              <b> avant / après</b> à leur journée, depuis <b>Ma journée</b> dans leur espace.
+            </>
+          ) : (
+            "Aucun rapport ne correspond à ce filtre."
+          )}
+        </div>
+      )}
+
+      <div className="grid gap-3 md:grid-cols-2">
+        {rapports.map((r) => {
+          const enVitrine = r.apres.length > 0 && vitrine.includes(r.apres[0]);
+          const nom = r.booking
+            ? `${r.booking.firstName} ${r.booking.lastName}`.trim() || "Client sans nom"
+            : "Chantier sans rendez-vous";
+          return (
+            <article
+              key={r.id}
+              className={`card !p-4 ${r.validated ? "border-leaf-300 bg-leaf-50/40" : ""}`}
+            >
+              <div className="mb-3 flex items-start gap-3">
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-leaf-50 text-leaf-700">
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-5 w-5">
+                    <circle cx="12" cy="8" r="4" />
+                    <path d="M4 21v-1a6 6 0 0 1 6-6h4a6 6 0 0 1 6 6v1" />
+                  </svg>
+                </span>
+                <div className="min-w-0">
+                  <p className="truncate font-bold">{nom}</p>
+                  <p className="text-sm text-leaf-800/70">{jourFr(r.date)}</p>
+                  <p className="text-xs text-leaf-800/60">
+                    Créé par : {r.pro?.name ?? "—"}
+                    {r.booking?.city ? ` · ${r.booking.city}` : ""}
+                    {r.booking ? ` · ${PRESTATIONS[r.booking.projectType] ?? ""}` : ""}
+                  </p>
+                </div>
+              </div>
+
+              <Duo avant={r.avant} apres={r.apres} />
+
+              <div className="mt-3 flex items-center gap-3 border-t border-leaf-100 pt-3 text-sm">
+                <button
+                  onClick={() => agir(r.id, { validated: !r.validated })}
+                  className={`flex items-center gap-1.5 font-semibold ${
+                    r.validated ? "text-leaf-800/60" : "text-leaf-700"
+                  }`}
+                >
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="h-4 w-4">
+                    <path d="m4 12 5 5L20 6" />
+                  </svg>
+                  {r.validated ? "Rouvrir" : "Terminer"}
+                </button>
+
+                <button
+                  onClick={() => agir(r.id, { publier: !enVitrine })}
+                  title={
+                    enVitrine
+                      ? "Retirer cette photo de la page d'accueil"
+                      : "Mettre la photo « après » en vitrine sur la page d'accueil"
+                  }
+                  className={enVitrine ? "text-amber-500" : "text-leaf-800/30 hover:text-amber-500"}
+                  disabled={r.apres.length === 0}
+                >
+                  <svg viewBox="0 0 24 24" fill={enVitrine ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" className="h-5 w-5">
+                    <path d="m12 3 2.9 5.9 6.5.9-4.7 4.6 1.1 6.5L12 17.8 6.2 20.9l1.1-6.5L2.6 9.8l6.5-.9z" />
+                  </svg>
+                </button>
+
+                <button
+                  onClick={() => supprimer(r)}
+                  title="Supprimer les photos (les heures pointées sont conservées)"
+                  className="ml-auto text-red-500 hover:text-red-700"
+                >
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-5 w-5">
+                    <path d="M3 6h18M8 6V4h8v2M19 6l-1 14H6L5 6" />
+                  </svg>
+                </button>
+              </div>
+            </article>
+          );
+        })}
+      </div>
+    </main>
+  );
+}

--- a/app/src/app/api/admin/chantiers/[id]/route.ts
+++ b/app/src/app/api/admin/chantiers/[id]/route.ts
@@ -1,0 +1,95 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+const MAX_GALERIE = 6;
+
+function photos(json: string): string[] {
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr.filter((p) => typeof p === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * PATCH /api/admin/chantiers/:id — { validated } marque le rapport comme
+ * terminé ; { publier } met la photo « après » en vitrine sur la page
+ * d'accueil (ou l'en retire).
+ */
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+  const journee = await prisma.workEntry.findUnique({ where: { id: params.id } });
+  if (!journee) return NextResponse.json({ error: "introuvable" }, { status: 404 });
+
+  if (body.validated !== undefined) {
+    await prisma.workEntry.update({
+      where: { id: params.id },
+      data: { validated: Boolean(body.validated) },
+    });
+  }
+
+  if (body.publier !== undefined) {
+    const apres = photos(journee.photosAfterJson);
+    if (!apres.length) {
+      return NextResponse.json(
+        { error: "Ce rapport n'a pas de photo « après » à mettre en vitrine." },
+        { status: 400 }
+      );
+    }
+    const photo = apres[0];
+    const existante = await prisma.galleryPhoto.findFirst({ where: { dataUrl: photo } });
+    if (body.publier) {
+      if (!existante) {
+        const nb = await prisma.galleryPhoto.count();
+        if (nb >= MAX_GALERIE) {
+          return NextResponse.json(
+            {
+              error: `La vitrine est pleine (${MAX_GALERIE} photos). Retirez-en une depuis Paramètres → Photos de réalisations.`,
+            },
+            { status: 400 }
+          );
+        }
+        await prisma.galleryPhoto.create({ data: { dataUrl: photo, sort: nb } });
+      }
+    } else if (existante) {
+      await prisma.galleryPhoto.delete({ where: { id: existante.id } });
+    }
+  }
+
+  return NextResponse.json({ ok: true });
+}
+
+/**
+ * DELETE /api/admin/chantiers/:id — supprime UNIQUEMENT les photos du rapport.
+ * Les heures pointées de la journée sont conservées : elles servent à la paie
+ * et à la facturation des sous-traitants.
+ */
+export async function DELETE(_req: NextRequest, { params }: { params: { id: string } }) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const journee = await prisma.workEntry.findUnique({ where: { id: params.id } });
+  if (!journee) return NextResponse.json({ error: "introuvable" }, { status: 404 });
+
+  // Les photos mises en vitrine depuis ce rapport sont retirées avec lui.
+  for (const p of photos(journee.photosAfterJson)) {
+    await prisma.galleryPhoto.deleteMany({ where: { dataUrl: p } });
+  }
+  await prisma.workEntry.update({
+    where: { id: params.id },
+    data: { photosBeforeJson: "[]", photosAfterJson: "[]" },
+  });
+  return NextResponse.json({ ok: true });
+}

--- a/app/src/app/api/admin/chantiers/route.ts
+++ b/app/src/app/api/admin/chantiers/route.ts
@@ -1,0 +1,106 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { parisTimeToUtc, addDaysStr } from "@/lib/dates";
+
+export const dynamic = "force-dynamic";
+
+const MAX_RESULTATS = 60;
+
+function photos(json: string): string[] {
+  try {
+    const arr = JSON.parse(json);
+    return Array.isArray(arr) ? arr.filter((p) => typeof p === "string") : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * GET /api/admin/chantiers?etat=en_cours|termines&client= — les rapports
+ * d'intervention avant / après, tels que les paysagistes les remplissent
+ * depuis leur pointage. Une carte = une journée sur un chantier.
+ *
+ * Le rapport est rattaché au client via le rendez-vous de ce paysagiste ce
+ * jour-là ; sans rendez-vous, la carte reste utile (photos + auteur).
+ */
+export async function GET(req: NextRequest) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  const p = req.nextUrl.searchParams;
+  const etat = p.get("etat") ?? "en_cours";
+  const contactId = (p.get("client") ?? "").trim();
+
+  // Seules les journées comportant au moins une photo sont des « rapports ».
+  const journees = await prisma.workEntry.findMany({
+    where: {
+      validated: etat === "termines",
+      NOT: [{ photosBeforeJson: "[]" }, { photosAfterJson: "[]" }],
+    },
+    orderBy: { date: "desc" },
+    take: MAX_RESULTATS * 2,
+    include: { pro: { select: { id: true, name: true } } },
+  });
+
+  // Le chantier du jour pour ce paysagiste : donne le client et l'adresse.
+  const rapports = [];
+  for (const j of journees) {
+    const booking = await prisma.booking.findFirst({
+      where: {
+        proId: j.proId,
+        status: { not: "annule" },
+        startAt: {
+          gte: parisTimeToUtc(j.date, "00:00"),
+          lt: parisTimeToUtc(addDaysStr(j.date, 1), "00:00"),
+        },
+      },
+      select: {
+        id: true,
+        contactId: true,
+        firstName: true,
+        lastName: true,
+        city: true,
+        address: true,
+        projectType: true,
+      },
+    });
+    if (contactId && booking?.contactId !== contactId) continue;
+    const avant = photos(j.photosBeforeJson);
+    const apres = photos(j.photosAfterJson);
+    if (!avant.length && !apres.length) continue;
+    rapports.push({
+      id: j.id,
+      date: j.date,
+      validated: j.validated,
+      pro: j.pro,
+      avant,
+      apres,
+      booking,
+    });
+    if (rapports.length >= MAX_RESULTATS) break;
+  }
+
+  // Les clients ayant au moins un chantier : alimente le filtre.
+  const clients = await prisma.contact.findMany({
+    where: { bookings: { some: { kind: "chantier" } } },
+    orderBy: [{ lastName: "asc" }, { firstName: "asc" }],
+    select: { id: true, firstName: true, lastName: true },
+  });
+
+  // Compteurs des deux onglets, indépendants du filtre en cours.
+  const [enCours, termines] = await Promise.all([
+    prisma.workEntry.count({
+      where: { validated: false, NOT: [{ photosBeforeJson: "[]" }, { photosAfterJson: "[]" }] },
+    }),
+    prisma.workEntry.count({
+      where: { validated: true, NOT: [{ photosBeforeJson: "[]" }, { photosAfterJson: "[]" }] },
+    }),
+  ]);
+
+  return NextResponse.json({
+    rapports,
+    clients,
+    compteurs: { enCours, termines, total: enCours + termines },
+  });
+}


### PR DESCRIPTION
Nouvelle entrée « Chantiers » dans l'espace gérant, sur le modèle de la maquette
fournie par le client (« Rapports d'intervention avant / après »).

Les données existent déjà : ce sont les photos avant/après que les paysagistes
joignent à leur journée depuis **Ma journée** (`WorkEntry.photosBeforeJson` /
`photosAfterJson`). Cette page les rassemble côté gérant.

## Ce qui a été ajouté

- `GET /api/admin/chantiers?etat=&client=` — les journées pointées comportant au
  moins une photo. Le client, la ville et la prestation viennent du rendez-vous
  du paysagiste ce jour-là ; sans rendez-vous, la carte reste utile (photos +
  auteur). Onglets **En cours / Terminés** avec compteurs, filtre par client.
- `PATCH /api/admin/chantiers/:id`
  - `{ validated }` → bouton **Terminer / Rouvrir** (c'est la validation gérant
    déjà utilisée par la gestion terrain).
  - `{ publier }` → l'**étoile** met la photo « après » en vitrine sur la page
    d'accueil (`GalleryPhoto`, 6 maximum, message clair si la vitrine est pleine).
- `DELETE /api/admin/chantiers/:id` — supprime **uniquement les photos**. Les
  heures pointées de la journée sont conservées : elles servent à la paie et à la
  facturation des sous-traitants. La confirmation le dit explicitement.
- `/admin/chantiers` — cartes avant/après (2 vignettes par côté, pastille « +N »,
  clic = plein écran), onglets, filtre client, entrée dans la barre latérale.

## Vérifications

Base de test avec 2 paysagistes, 3 rapports (dont 1 déjà terminé) et une journée
pointée sans photo :

- la journée sans photo n'apparaît pas comme rapport ;
- compteurs « En cours (2) / Terminés (1) » corrects, filtre client opérationnel ;
- étoile → 1 photo en vitrine ;
- « Terminer » → la carte bascule bien dans l'autre onglet ;
- suppression des photos → les 4 journées de pointage sont toujours là.

`npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_