### PR TITLE
Page de connexion : « Je suis un client »

### DIFF
--- a/app/src/app/connexion/page.tsx
+++ b/app/src/app/connexion/page.tsx
@@ -17,7 +17,7 @@ export default function ConnexionPage() {
 
       <div className="space-y-3">
         <Link href="/compte/login" className="card block transition hover:border-leaf-300">
-          <p className="font-bold text-leaf-900">Je suis un particulier</p>
+          <p className="font-bold text-leaf-900">Je suis un client</p>
           <p className="mt-1 text-sm text-leaf-800/70">
             Suivez et gérez vos rendez-vous de devis et d&apos;entretien.
           </p>


### PR DESCRIPTION
Sur `/connexion`, le premier choix s'intitulait « Je suis un particulier ».
Il devient **« Je suis un client »**, à la demande du client — un mot plus
direct pour le visiteur. Le choix « Je suis un professionnel » est inchangé.

Seul le libellé affiché change ; aucune route ni logique de compte n'est
touchée. `npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_