### PR TITLE
Espace client : dire clairement visite de devis ou chantier

### DIFF
--- a/app/src/app/admin/clients/page.tsx
+++ b/app/src/app/admin/clients/page.tsx
@@ -5,6 +5,7 @@
 // ligne s'ouvre sur la fiche complète (coordonnées, RDV, journal des échanges).
 import { Fragment, useEffect, useState } from "react";
 import FicheContact from "./FicheContact";
+import { telFr } from "@/lib/rdvLabels";
 
 export type Contact = {
   id: string;
@@ -35,13 +36,6 @@ type AgenceLite = { id: string; nom: string; couleur: string };
 function euros(n: number): string {
   return n.toLocaleString("fr-FR", { style: "currency", currency: "EUR", maximumFractionDigits: 0 });
 }
-/** « 0651525354 » → « 06 51 52 53 54 » : lisible d'un coup d'œil. */
-function telFr(t: string): string {
-  const d = (t || "").replace(/\D/g, "");
-  if (d.length === 10) return d.replace(/(\d{2})(?=\d)/g, "$1 ").trim();
-  return t;
-}
-
 function dateCourte(iso: string | null): string {
   if (!iso) return "—";
   return new Date(iso).toLocaleDateString("fr-FR", {

--- a/app/src/app/annuler/[token]/page.tsx
+++ b/app/src/app/annuler/[token]/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import SiteHeader from "@/components/SiteHeader";
 import { prisma } from "@/lib/prisma";
 import { formatDateFr, formatTimeFr } from "@/lib/dates";
+import { kindMeta } from "@/lib/rdvLabels";
 import CancelActions from "./CancelActions";
 
 export const dynamic = "force-dynamic";
@@ -18,18 +19,22 @@ export default async function CancelPage({ params }: { params: { token: string }
     select: { startAt: true },
   });
   const isGroup = group.length > 1;
+  const meta = kindMeta(booking.kind);
 
   return (
     <main className="mx-auto flex min-h-screen max-w-lg flex-col justify-center px-4 py-6">
       <SiteHeader />
       <h1 className="mt-4 text-2xl font-extrabold">Modifier ou annuler votre rendez-vous</h1>
-      <div className="card mt-5 space-y-1">
+      <div className={`card mt-5 space-y-1 ${meta.filet}`}>
+        <span className={`inline-block rounded-full px-3 py-1 text-sm font-bold ${meta.pastille}`}>
+          {meta.titre}
+        </span>
         {isGroup ? (
           <>
             <p className="font-semibold">Chantier de {group.length} jours, dès 8h00 :</p>
             <ul className="ml-5 list-disc text-sm text-leaf-900">
               {group.map((g, i) => (
-                <li key={i} className="capitalize">{formatDateFr(g.startAt)}</li>
+                <li key={i} className="first-letter:uppercase">{formatDateFr(g.startAt)}</li>
               ))}
             </ul>
           </>

--- a/app/src/app/api/client/me/route.ts
+++ b/app/src/app/api/client/me/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { currentClientId } from "@/lib/clientAuth";
+import { getSettings } from "@/lib/settings";
 
 export const dynamic = "force-dynamic";
 
@@ -19,16 +20,25 @@ export async function GET() {
       id: true,
       kind: true,
       projectType: true,
+      description: true,
       startAt: true,
+      endAt: true,
+      // Chantier multi-jours : permet de regrouper les jours en un seul RDV.
+      groupId: true,
       address: true,
       postalCode: true,
       city: true,
       status: true,
       cancelToken: true,
+      // Le prénom du paysagiste attribué : le client sait qui vient chez lui.
+      pro: { select: { name: true } },
     },
   });
 
+  const settings = await getSettings();
+
   return NextResponse.json({
+    entreprise: { nom: settings.companyName, telephone: settings.companyPhone },
     client: {
       name: client.name,
       email: client.email,
@@ -37,7 +47,11 @@ export async function GET() {
       postalCode: client.postalCode,
       city: client.city,
     },
-    bookings,
+    // Le client voit le prénom de son paysagiste, pas son nom complet.
+    bookings: bookings.map(({ pro, ...b }) => ({
+      ...b,
+      proPrenom: pro?.name?.trim().split(/\s+/)[0] ?? "",
+    })),
   });
 }
 

--- a/app/src/app/api/rdv/[token]/ics/route.ts
+++ b/app/src/app/api/rdv/[token]/ics/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getSettings } from "@/lib/settings";
+import { buildIcsGroup } from "@/lib/ics";
+
+export const dynamic = "force-dynamic";
+
+/**
+ * GET /api/rdv/:token/ics — « Ajouter à mon agenda ».
+ *
+ * Le jeton est celui du lien d'annulation, déjà connu du client (SMS, email,
+ * espace personnel) : pas besoin d'être connecté, et rien d'autre n'est exposé
+ * que le rendez-vous correspondant. Un chantier de plusieurs jours renvoie
+ * autant d'événements dans un seul fichier.
+ */
+export async function GET(_req: NextRequest, { params }: { params: { token: string } }) {
+  const booking = await prisma.booking.findUnique({ where: { cancelToken: params.token } });
+  if (!booking || booking.status === "annule") {
+    return NextResponse.json({ error: "introuvable" }, { status: 404 });
+  }
+  const principal = booking.groupId || booking.id;
+  const jours = await prisma.booking.findMany({
+    where: { OR: [{ id: principal }, { groupId: principal }] },
+    orderBy: { startAt: "asc" },
+  });
+  const settings = await getSettings();
+  const ics = buildIcsGroup(jours.length ? jours : [booking], settings);
+  if (!ics) {
+    return NextResponse.json({ error: "Ce rendez-vous n'a pas encore de date." }, { status: 400 });
+  }
+  return new NextResponse(ics, {
+    headers: {
+      "Content-Type": "text/calendar; charset=utf-8",
+      "Content-Disposition": 'attachment; filename="rendez-vous.ics"',
+    },
+  });
+}

--- a/app/src/app/compte/page.tsx
+++ b/app/src/app/compte/page.tsx
@@ -1,20 +1,35 @@
 "use client";
 
-// Espace particulier : liste des rendez-vous (à venir / passés), gestion.
-import { useEffect, useState } from "react";
+// Espace particulier : ses rendez-vous, dits clairement (visite de devis ou
+// chantier), puis ses coordonnées. Un chantier réservé sur plusieurs jours
+// s'affiche en un seul rendez-vous, comme le client l'a vécu en le réservant.
+import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import AddressAutocomplete, { type AddressValue } from "@/components/AddressAutocomplete";
+import {
+  PROJECT_LABELS,
+  creneauLabel,
+  dateLongue,
+  delaiLabel,
+  kindMeta,
+  statutClient,
+  telFr,
+} from "@/lib/rdvLabels";
 
 type Booking = {
   id: string;
   kind: string;
   projectType: string;
+  description: string;
   startAt: string | null;
+  endAt: string | null;
+  groupId: string;
   address: string;
   postalCode: string;
   city: string;
   status: string;
   cancelToken: string;
+  proPrenom: string;
 };
 type Client = {
   name: string;
@@ -24,38 +39,65 @@ type Client = {
   postalCode: string;
   city: string;
 };
+type Entreprise = { nom: string; telephone: string };
 
-const PROJECT_LABELS: Record<string, string> = {
-  entretien: "Entretien de jardin général",
-  taille_haie: "Taille de haie",
-  debroussaillage: "Débroussaillage",
-  contrat_annuel: "Contrat d'entretien à l'année",
-  autre: "Autre projet",
-};
-const STATUS_LABELS: Record<string, string> = {
-  a_faire: "À venir",
-  devis_envoye: "Devis envoyé",
-  gagne: "Confirmé",
-  perdu: "Clôturé",
-  annule: "Annulé",
+/** Un rendez-vous tel que le client le comprend : un chantier de 3 jours = 1. */
+type Rdv = {
+  cle: string;
+  principal: Booking;
+  jours: Booking[];
+  debut: string | null;
+  fin: string | null;
 };
 
-function fmt(iso: string | null): string {
-  if (!iso) return "Date à définir";
-  return new Date(iso).toLocaleString("fr-FR", {
-    timeZone: "Europe/Paris",
-    weekday: "long",
-    day: "numeric",
-    month: "long",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
+function regrouper(bookings: Booking[]): Rdv[] {
+  const paquets = new Map<string, Booking[]>();
+  for (const b of bookings) {
+    const cle = b.groupId || b.id;
+    paquets.set(cle, [...(paquets.get(cle) ?? []), b]);
+  }
+  return Array.from(paquets.entries())
+    .map(([cle, liste]) => {
+      const jours = [...liste].sort((a, b) =>
+        (a.startAt ?? "").localeCompare(b.startAt ?? "")
+      );
+      return {
+        cle,
+        // Le rendez-vous principal porte le lien d'annulation du groupe.
+        principal: jours.find((j) => j.id === cle) ?? jours[0],
+        jours,
+        debut: jours[0].startAt,
+        fin: jours[jours.length - 1].startAt,
+      };
+    })
+    .sort((a, b) => (b.debut ?? "").localeCompare(a.debut ?? ""));
+}
+
+function Icone({ kind }: { kind: string }) {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" className="h-5 w-5">
+      {kind === "chantier" ? (
+        <>
+          <path d="M3 21h18" />
+          <path d="M6 21V9l6-4 6 4v12" />
+          <path d="M10 21v-6h4v6" />
+        </>
+      ) : (
+        <>
+          <rect x="3" y="5" width="18" height="16" rx="2" />
+          <path d="M8 3v4M16 3v4M3 11h18" />
+        </>
+      )}
+    </svg>
+  );
 }
 
 export default function ClientAccount() {
   const [client, setClient] = useState<Client | null>(null);
+  const [entreprise, setEntreprise] = useState<Entreprise>({ nom: "", telephone: "" });
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [loading, setLoading] = useState(true);
+  const [historique, setHistorique] = useState(false);
   // Fiche « Mes coordonnées » (modifiable)
   const [editing, setEditing] = useState(false);
   const [name, setName] = useState("");
@@ -87,6 +129,7 @@ export default function ClientAccount() {
       .then((data) => {
         setClient(data.client);
         if (data.client) fillForm(data.client);
+        if (data.entreprise) setEntreprise(data.entreprise);
         setBookings(data.bookings ?? []);
       })
       .finally(() => setLoading(false));
@@ -129,33 +172,109 @@ export default function ClientAccount() {
   }
 
   const now = Date.now();
+  const rdvs = useMemo(() => regrouper(bookings), [bookings]);
   // Un devis « sans date » (créé par le gérant) reste dans « À venir ».
-  const upcoming = bookings.filter(
-    (b) => (!b.startAt || new Date(b.startAt).getTime() >= now) && b.status !== "annule"
+  const aVenir = rdvs
+    .filter(
+      (r) =>
+        r.principal.status !== "annule" && (!r.fin || new Date(r.fin).getTime() >= now)
+    )
+    .reverse(); // le plus proche en premier
+  const passes = rdvs.filter(
+    (r) =>
+      r.principal.status === "annule" || (r.fin != null && new Date(r.fin).getTime() < now)
   );
-  const past = bookings.filter(
-    (b) => b.startAt && (new Date(b.startAt).getTime() < now || b.status === "annule")
-  );
+  const prochain = aVenir[0];
 
-  function card(b: Booking) {
+  function Carte({ r, vedette }: { r: Rdv; vedette?: boolean }) {
+    const b = r.principal;
+    const meta = kindMeta(b.kind);
+    const passe = r.fin != null && new Date(r.fin).getTime() < now;
+    const statut = statutClient(b.kind, b.status, passe);
+    const multi = r.jours.length > 1;
+    const delai = b.status === "annule" ? "" : delaiLabel(r.debut, now);
+    const annulable = b.status !== "annule" && (!r.debut || new Date(r.debut).getTime() >= now);
+
+    // Un rendez-vous annulé garde sa place mais perd sa couleur : on le
+    // reconnaît d'un coup d'œil sans le confondre avec un rendez-vous actif.
+    const annule = b.status === "annule";
     return (
-      <div key={b.id} className="card">
-        <div className="flex items-start justify-between gap-2">
-          <p className="font-semibold capitalize">{fmt(b.startAt)}</p>
-          <span className="rounded-full bg-leaf-100 px-2.5 py-0.5 text-[11px] font-semibold text-leaf-800">
-            {b.kind === "chantier" ? "Chantier" : "Devis"}
+      <article
+        className={`card ${
+          annule ? "border-l-4 border-l-leaf-200 opacity-70" : meta.filet
+        } ${vedette ? "shadow-md" : ""}`}
+      >
+        <div className="flex flex-wrap items-center gap-2">
+          <span
+            className={`flex items-center gap-1.5 rounded-full px-3 py-1 text-sm font-bold ${
+              annule ? "bg-leaf-100 text-leaf-800/60" : meta.pastille
+            }`}
+          >
+            <Icone kind={b.kind} />
+            {multi ? `${meta.titre} · ${r.jours.length} jours` : meta.titre}
+          </span>
+          <span className={`ml-auto rounded-full px-2.5 py-1 text-xs font-semibold ${statut.classe}`}>
+            {statut.label}
           </span>
         </div>
-        <p className="mt-1 text-sm text-leaf-800/70">
-          {PROJECT_LABELS[b.projectType] ?? b.projectType} · {b.city || b.postalCode}
+
+        <p className="mt-3 text-lg font-bold leading-tight first-letter:uppercase">
+          {multi
+            ? `Du ${dateLongue(r.debut)} au ${dateLongue(r.fin)}`
+            : dateLongue(r.debut)}
         </p>
-        <p className="mt-1 text-sm text-leaf-800/60">{STATUS_LABELS[b.status] ?? b.status}</p>
-        {b.status !== "annule" && b.startAt && new Date(b.startAt).getTime() >= now && (
-          <Link href={`/annuler/${b.cancelToken}`} className="mt-2 inline-block text-sm font-semibold text-leaf-700 underline">
-            Modifier ou annuler
-          </Link>
+        {r.debut && (
+          <p className="text-sm text-leaf-800/70">
+            {multi
+              ? "Tous les jours dès 8h00"
+              : creneauLabel(b.kind, r.debut, b.endAt)}
+            {delai && <span className="font-semibold text-leaf-700"> · {delai}</span>}
+          </p>
         )}
-      </div>
+
+        <dl className="mt-3 space-y-1 text-sm text-leaf-800/80">
+          <div className="flex gap-2">
+            <dt className="w-28 shrink-0 text-leaf-800/50">Prestation</dt>
+            <dd>{PROJECT_LABELS[b.projectType] ?? b.projectType}</dd>
+          </div>
+          <div className="flex gap-2">
+            <dt className="w-28 shrink-0 text-leaf-800/50">Adresse</dt>
+            <dd>
+              {b.address ? `${b.address}, ` : ""}
+              {b.postalCode} {b.city}
+            </dd>
+          </div>
+          {b.proPrenom && b.kind === "chantier" && (
+            <div className="flex gap-2">
+              <dt className="w-28 shrink-0 text-leaf-800/50">Paysagiste</dt>
+              <dd>{b.proPrenom}</dd>
+            </div>
+          )}
+        </dl>
+
+        {/* Le rappel pratique n'a d'intérêt que sur le rendez-vous mis en avant
+            et sur les chantiers (accès au jardin) : ailleurs il se répète. */}
+        {!passe && b.status !== "annule" && (vedette || b.kind === "chantier") && (
+          <p className="mt-3 rounded-xl bg-leaf-50 px-3 py-2 text-sm text-leaf-800/80">
+            {multi ? meta.explication.replace("ce jour-là", "ces jours-là") : meta.explication}
+          </p>
+        )}
+
+        {(annulable || (r.debut && !passe && b.status !== "annule")) && (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {r.debut && !passe && b.status !== "annule" && (
+              <a href={`/api/rdv/${b.cancelToken}/ics`} className="btn-secondary !py-2 text-sm">
+                Ajouter à mon agenda
+              </a>
+            )}
+            {annulable && (
+              <Link href={`/annuler/${b.cancelToken}`} className="btn-secondary !py-2 text-sm">
+                Modifier ou annuler
+              </Link>
+            )}
+          </div>
+        )}
+      </article>
     );
   }
 
@@ -175,9 +294,63 @@ export default function ClientAccount() {
 
       {!loading && (
         <>
+          {prochain ? (
+            <section className="mb-6">
+              <h2 className="mb-2 text-lg font-bold">Votre prochain rendez-vous</h2>
+              <Carte r={prochain} vedette />
+            </section>
+          ) : (
+            <section className="card mb-6 text-center">
+              <p className="font-bold">Aucun rendez-vous prévu</p>
+              <p className="mt-1 text-sm text-leaf-800/70">
+                Réservez une visite gratuite pour recevoir votre devis, ou une journée
+                d&apos;intervention si vous savez déjà ce dont vous avez besoin.
+              </p>
+            </section>
+          )}
+
           <div className="mb-6 flex flex-col gap-2 sm:flex-row">
-            <Link href="/#reserver" className="btn-primary">Réserver un rendez-vous</Link>
+            <Link href="/#reserver" className="btn-primary flex-1 text-center">
+              Demander un devis gratuit
+            </Link>
+            <Link href="/#chantier" className="btn-secondary flex-1 text-center">
+              Réserver un chantier
+            </Link>
           </div>
+
+          {aVenir.length > 1 && (
+            <section className="mb-6">
+              <h2 className="mb-3 text-lg font-bold">
+                Vos autres rendez-vous ({aVenir.length - 1})
+              </h2>
+              <div className="space-y-3">
+                {aVenir.slice(1).map((r) => (
+                  <Carte key={r.cle} r={r} />
+                ))}
+              </div>
+            </section>
+          )}
+
+          {passes.length > 0 && (
+            <section className="mb-6">
+              <button
+                onClick={() => setHistorique((v) => !v)}
+                className="mb-3 flex w-full items-center justify-between text-lg font-bold"
+              >
+                Historique ({passes.length})
+                <span className="text-sm font-semibold text-leaf-700">
+                  {historique ? "Masquer" : "Afficher"}
+                </span>
+              </button>
+              {historique && (
+                <div className="space-y-3">
+                  {passes.map((r) => (
+                    <Carte key={r.cle} r={r} />
+                  ))}
+                </div>
+              )}
+            </section>
+          )}
 
           {/* Coordonnées enregistrées : reprises automatiquement à chaque réservation */}
           <section className="card mb-6">
@@ -198,7 +371,7 @@ export default function ClientAccount() {
 
             {!editing ? (
               <div className="mt-2 space-y-1 text-sm text-leaf-800/80">
-                <p>{client?.phone || "Téléphone non renseigné"}</p>
+                <p>{client?.phone ? telFr(client.phone) : "Téléphone non renseigné"}</p>
                 <p>{client?.email}</p>
                 {client?.address ? (
                   <p>
@@ -239,20 +412,16 @@ export default function ClientAccount() {
             )}
           </section>
 
-          <h2 className="mb-3 text-lg font-bold">À venir ({upcoming.length})</h2>
-          {upcoming.length === 0 ? (
-            <p className="card py-6 text-center text-sm text-leaf-800/60">
-              Aucun rendez-vous à venir.
+          {entreprise.telephone && (
+            <p className="pb-4 text-center text-sm text-leaf-800/70">
+              Une question ?{" "}
+              <a
+                href={`tel:${entreprise.telephone.replace(/\s/g, "")}`}
+                className="font-semibold text-leaf-700 underline"
+              >
+                {entreprise.telephone}
+              </a>
             </p>
-          ) : (
-            <div className="space-y-3">{upcoming.map(card)}</div>
-          )}
-
-          {past.length > 0 && (
-            <>
-              <h2 className="mb-3 mt-8 text-lg font-bold">Historique</h2>
-              <div className="space-y-3">{past.map(card)}</div>
-            </>
           )}
         </>
       )}

--- a/app/src/app/confirmation/[id]/page.tsx
+++ b/app/src/app/confirmation/[id]/page.tsx
@@ -4,6 +4,7 @@ import SiteHeader from "@/components/SiteHeader";
 import { prisma } from "@/lib/prisma";
 import { getSettings } from "@/lib/settings";
 import { formatDateFr, formatTimeFr } from "@/lib/dates";
+import { kindMeta, telFr } from "@/lib/rdvLabels";
 
 export const dynamic = "force-dynamic";
 
@@ -11,6 +12,7 @@ export default async function ConfirmationPage({ params }: { params: { id: strin
   const booking = await prisma.booking.findUnique({ where: { id: params.id } });
   if (!booking) notFound();
   const settings = await getSettings();
+  const meta = kindMeta(booking.kind);
   // Chantier multi-jours : tous les jours du groupe.
   const group = await prisma.booking.findMany({
     where: { OR: [{ id: booking.id }, { groupId: booking.id }] },
@@ -24,18 +26,21 @@ export default async function ConfirmationPage({ params }: { params: { id: strin
       <span className="mt-4 flex h-16 w-16 items-center justify-center rounded-full bg-leaf-600 text-3xl text-white">
         ✓
       </span>
-      <h1 className="mt-5 text-2xl font-extrabold">Rendez-vous confirmé !</h1>
+      <h1 className="mt-5 text-2xl font-extrabold">C&apos;est confirmé !</h1>
       <p className="mt-2 text-leaf-800/80">
-        Un SMS de confirmation vient de vous être envoyé au {booking.phone}.
+        Un SMS de confirmation vient de vous être envoyé au {telFr(booking.phone)}.
       </p>
 
-      <div className="card mt-6 w-full space-y-2 text-left">
+      <div className={`card mt-6 w-full space-y-2 text-left ${meta.filet}`}>
+        <span className={`inline-block rounded-full px-3 py-1 text-sm font-bold ${meta.pastille}`}>
+          {meta.titre}
+        </span>
         {group.length > 1 ? (
           <>
             <p className="font-semibold">Chantier de {group.length} jours, dès 8h00 :</p>
             <ul className="ml-6 list-disc">
               {group.map((g, i) => (
-                <li key={i} className="capitalize">{formatDateFr(g.startAt)}</li>
+                <li key={i} className="first-letter:uppercase">{formatDateFr(g.startAt)}</li>
               ))}
             </ul>
           </>
@@ -47,13 +52,24 @@ export default async function ConfirmationPage({ params }: { params: { id: strin
         )}
         <p>{booking.address}, {booking.postalCode} {booking.city}</p>
         <p>{settings.companyName} — {settings.companyPhone}</p>
+        <p className="rounded-xl bg-leaf-50 px-3 py-2 text-sm text-leaf-800/80">
+          {group.length > 1
+            ? meta.explication.replace("ce jour-là", "ces jours-là")
+            : meta.explication}
+        </p>
       </div>
 
       <p className="mt-4 text-sm text-leaf-800/70">
         Vous recevrez un rappel SMS 24 h et 1 h avant le rendez-vous. Un email avec
         l&apos;invitation calendrier (.ics) vous a également été envoyé.
       </p>
-      <Link href="/" className="btn-secondary mt-6">← Retour à l&apos;accueil</Link>
+      <a href={`/api/rdv/${booking.cancelToken}/ics`} className="btn-primary mt-6 w-full text-center">
+        Ajouter à mon agenda
+      </a>
+      <Link href="/compte" className="mt-3 text-sm font-semibold text-leaf-700 underline">
+        Retrouver ce rendez-vous dans mon espace
+      </Link>
+      <Link href="/" className="btn-secondary mt-4">← Retour à l&apos;accueil</Link>
     </main>
   );
 }

--- a/app/src/lib/ics.ts
+++ b/app/src/lib/ics.ts
@@ -1,4 +1,5 @@
-// Génération d'un fichier .ics (invitation calendrier) pour l'email de confirmation.
+// Génération d'un fichier .ics (invitation calendrier) : pièce jointe de l'email
+// de confirmation et bouton « Ajouter à mon agenda » dans l'espace client.
 import type { Booking, Settings } from "@prisma/client";
 
 function icsDate(d: Date): string {
@@ -9,27 +10,47 @@ function escapeIcs(s: string): string {
   return s.replace(/\\/g, "\\\\").replace(/;/g, "\\;").replace(/,/g, "\\,").replace(/\n/g, "\\n");
 }
 
+function vevent(booking: Booking, settings: Settings): string[] {
+  const location = `${booking.address}, ${booking.postalCode} ${booking.city}`;
+  const chantier = booking.kind === "chantier";
+  const titre = chantier ? "Chantier" : "Visite pour devis";
+  return [
+    "BEGIN:VEVENT",
+    `UID:${booking.id}@rdv-devis`,
+    `DTSTAMP:${icsDate(new Date())}`,
+    `DTSTART:${icsDate(booking.startAt!)}`,
+    `DTEND:${icsDate(booking.endAt!)}`,
+    `SUMMARY:${escapeIcs(`${titre} — ${settings.companyName}`)}`,
+    `LOCATION:${escapeIcs(location)}`,
+    `DESCRIPTION:${escapeIcs(
+      `${
+        chantier
+          ? "Intervention de nos paysagistes chez vous."
+          : "Rendez-vous pour l'établissement d'un devis."
+      }\nContact : ${settings.companyPhone}`
+    )}`,
+    "STATUS:CONFIRMED",
+    "END:VEVENT",
+  ];
+}
+
+/** Un rendez-vous. Chaîne vide si la date n'est pas encore fixée. */
 export function buildIcs(booking: Booking, settings: Settings): string {
   if (!booking.startAt || !booking.endAt) return ""; // pas d'invitation sans date
-  const location = `${booking.address}, ${booking.postalCode} ${booking.city}`;
+  return buildIcsGroup([booking], settings);
+}
+
+/** Plusieurs rendez-vous dans un seul fichier : chantier réservé sur N jours. */
+export function buildIcsGroup(bookings: Booking[], settings: Settings): string {
+  const dates = bookings.filter((b) => b.startAt && b.endAt);
+  if (!dates.length) return "";
   return [
     "BEGIN:VCALENDAR",
     "VERSION:2.0",
     `PRODID:-//${escapeIcs(settings.companyName)}//RDV Devis//FR`,
     "CALSCALE:GREGORIAN",
     "METHOD:PUBLISH",
-    "BEGIN:VEVENT",
-    `UID:${booking.id}@rdv-devis`,
-    `DTSTAMP:${icsDate(new Date())}`,
-    `DTSTART:${icsDate(booking.startAt!)}`,
-    `DTEND:${icsDate(booking.endAt!)}`,
-    `SUMMARY:${escapeIcs(`RDV devis — ${settings.companyName}`)}`,
-    `LOCATION:${escapeIcs(location)}`,
-    `DESCRIPTION:${escapeIcs(
-      `Rendez-vous pour l'établissement d'un devis.\nContact : ${settings.companyPhone}`
-    )}`,
-    "STATUS:CONFIRMED",
-    "END:VEVENT",
+    ...dates.flatMap((b) => vevent(b, settings)),
     "END:VCALENDAR",
   ].join("\r\n");
 }

--- a/app/src/lib/rdvLabels.ts
+++ b/app/src/lib/rdvLabels.ts
@@ -1,0 +1,134 @@
+// Libellés des rendez-vous côté client : le vocabulaire que voit le particulier
+// dans son espace, sur la confirmation et dans les emails. Module pur (aucun
+// accès à la base) pour pouvoir être importé par des composants « client ».
+
+export const PROJECT_LABELS: Record<string, string> = {
+  entretien: "Entretien de jardin général",
+  taille_haie: "Taille de haie",
+  debroussaillage: "Débroussaillage",
+  contrat_annuel: "Contrat d'entretien à l'année",
+  autre: "Autre projet",
+};
+
+export type KindMeta = {
+  /** Titre affiché en tête de carte. */
+  titre: string;
+  /** Version courte, pour les pastilles. */
+  court: string;
+  /** Ce qui va concrètement se passer — rassure le client. */
+  explication: string;
+  /** Classes Tailwind : pastille, filet de gauche, fond de l'entête. */
+  pastille: string;
+  filet: string;
+};
+
+// Bleu = visite de devis, vert = chantier : la même convention que l'agenda
+// du gérant, pour que tout le monde parle des mêmes couleurs.
+export const KIND_META: Record<string, KindMeta> = {
+  devis: {
+    titre: "Visite pour devis",
+    court: "Devis",
+    explication:
+      "Nous venons voir votre jardin sur place pour évaluer le travail, puis vous recevez votre devis. C'est gratuit et sans engagement.",
+    pastille: "bg-blue-100 text-blue-800",
+    filet: "border-l-4 border-l-blue-500",
+  },
+  chantier: {
+    titre: "Chantier",
+    court: "Chantier",
+    explication:
+      "Nos paysagistes interviennent chez vous. Pensez à laisser l'accès au jardin possible ce jour-là.",
+    pastille: "bg-leaf-100 text-leaf-800",
+    filet: "border-l-4 border-l-leaf-600",
+  },
+};
+
+export function kindMeta(kind: string): KindMeta {
+  return KIND_META[kind] ?? KIND_META.devis;
+}
+
+export type StatutClient = { label: string; classe: string };
+
+/**
+ * Le statut, dit avec les mots du client. Le même code interne ne veut pas dire
+ * la même chose pour une visite et pour un chantier — d'où le `kind`.
+ */
+export function statutClient(kind: string, status: string, passe: boolean): StatutClient {
+  const gris = "bg-leaf-100 text-leaf-800/70";
+  const vert = "bg-leaf-100 text-leaf-800";
+  const ambre = "bg-amber-100 text-amber-800";
+  switch (status) {
+    case "annule":
+      return { label: "Annulé", classe: gris };
+    case "devis_envoye":
+      return { label: "Devis envoyé", classe: ambre };
+    case "gagne":
+      return kind === "chantier"
+        ? { label: passe ? "Terminé" : "Confirmé", classe: vert }
+        : { label: "Devis accepté", classe: vert };
+    case "perdu":
+      return { label: "Sans suite", classe: gris };
+    default:
+      if (passe) {
+        return { label: kind === "chantier" ? "Terminé" : "Visite effectuée", classe: gris };
+      }
+      return { label: kind === "chantier" ? "Confirmé" : "Visite prévue", classe: vert };
+  }
+}
+
+const MIN = 60 * 1000;
+
+/**
+ * Le créneau en clair : « 17h00 → 17h30 (environ 30 min) » pour une visite,
+ * « 8h00 → 12h00 · demi-journée » pour un chantier.
+ */
+export function creneauLabel(kind: string, startAt: string | null, endAt: string | null): string {
+  if (!startAt) return "";
+  const heure = (iso: string) =>
+    new Date(iso).toLocaleTimeString("fr-FR", {
+      timeZone: "Europe/Paris",
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  const debut = heure(startAt);
+  if (!endAt) return debut;
+  const minutes = Math.round((new Date(endAt).getTime() - new Date(startAt).getTime()) / MIN);
+  if (kind === "chantier") {
+    const formule = minutes <= 5 * 60 ? "demi-journée" : "journée entière";
+    return `${debut} → ${heure(endAt)} · ${formule}`;
+  }
+  return `${debut} · environ ${minutes} min`;
+}
+
+/** « aujourd'hui », « demain », « dans 3 jours »… ou rien si c'est loin. */
+export function delaiLabel(startAt: string | null, maintenant = Date.now()): string {
+  if (!startAt) return "";
+  const jour = (t: number) => {
+    const d = new Date(t);
+    return Date.UTC(d.getFullYear(), d.getMonth(), d.getDate());
+  };
+  const jours = Math.round((jour(new Date(startAt).getTime()) - jour(maintenant)) / 86400000);
+  if (jours < 0) return "";
+  if (jours === 0) return "aujourd'hui";
+  if (jours === 1) return "demain";
+  if (jours <= 14) return `dans ${jours} jours`;
+  return "";
+}
+
+/** « 0651525354 » → « 06 51 52 53 54 » : lisible d'un coup d'œil. */
+export function telFr(t: string): string {
+  const d = (t || "").replace(/\D/g, "");
+  if (d.length === 10) return d.replace(/(\d{2})(?=\d)/g, "$1 ").trim();
+  return t;
+}
+
+/** Date longue en français, fuseau de Paris. */
+export function dateLongue(startAt: string | null): string {
+  if (!startAt) return "Date à définir";
+  return new Date(startAt).toLocaleDateString("fr-FR", {
+    timeZone: "Europe/Paris",
+    weekday: "long",
+    day: "numeric",
+    month: "long",
+  });
+}


### PR DESCRIPTION
L'espace client affichait une date, une pastille « Devis »/« Chantier » discrète
et un statut interne (« À venir », « Confirmé »). Le client ne savait pas au
premier regard ce qui allait se passer chez lui, et un chantier réservé sur
3 jours apparaissait en 3 rendez-vous distincts alors qu'il n'en avait réservé
qu'un.

## Ce qui change

- **`lib/rdvLabels.ts`** (module partagé) : libellés et couleurs des deux types
  (bleu = visite, vert = chantier, la convention de l'agenda gérant), statuts
  traduits en mots de client, formulation du créneau, « dans N jours », mise en
  forme du téléphone.
- **`/compte` refait** autour de **« Votre prochain rendez-vous »** : pastille de
  type bien visible, date en gros, créneau et durée (« 17h00 · environ 30 min »,
  « 8h00 → 12h00 · demi-journée »), prestation, adresse, prénom du paysagiste
  attribué, et une phrase qui dit ce qui va se passer. Les autres rendez-vous
  suivent, l'historique est repliable, les coordonnées passent en bas.
- **Un chantier multi-jours = une seule carte** (« Chantier · 3 jours — du lundi
  24 au mercredi 26 août »).
- **« Ajouter à mon agenda »** : nouvelle route `GET /api/rdv/:token/ics`,
  authentifiée par le jeton que le client a déjà (SMS, email, espace). Un
  chantier de 3 jours produit les 3 événements dans un seul fichier. L'intitulé
  du .ics disait « RDV devis » même pour un chantier — corrigé.
- **Rendez-vous annulé** : filet gris et carte estompée, plus de bleu ou de vert.
- Les pages **confirmation** et **modifier/annuler** portent la même pastille de
  type, et la confirmation propose l'ajout à l'agenda et le lien vers l'espace.
- `/api/client/me` renvoie en plus `endAt`, `groupId`, le **prénom** du
  paysagiste (jamais son nom complet) et le téléphone de l'entreprise.
- Le tableau « Tous les clients » réutilise le `telFr` partagé au lieu de sa
  copie locale.

## Vérifications

Base de test : un compte client, une visite dans 2 jours, une visite « devis
envoyé », un chantier de 3 jours, un chantier passé en demi-journée, une visite
annulée.

- 3 cartes à venir (le chantier de 3 jours compte pour une), 2 en historique ;
- libellés : « Visite pour devis / Visite prévue », « Devis envoyé »,
  « Chantier · 3 jours / Confirmé », « Terminé », « Annulé » ;
- fichiers agenda : 1 événement pour une visite, **3 pour le chantier**, avec les
  intitulés « Visite pour devis — Arboris Paysage » et « Chantier — Arboris
  Paysage » ;
- rendu vérifié en largeur téléphone et en largeur ordinateur.

`npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_