### PR TITLE
Espace client : bouton « Rendez-vous chantier » et tri des RDV sans date

### DIFF
--- a/app/src/app/compte/page.tsx
+++ b/app/src/app/compte/page.tsx
@@ -173,13 +173,19 @@ export default function ClientAccount() {
 
   const now = Date.now();
   const rdvs = useMemo(() => regrouper(bookings), [bookings]);
-  // Un devis « sans date » (créé par le gérant) reste dans « À venir ».
+  // Un devis « sans date » (créé par le gérant) reste dans « À venir », mais en
+  // fin de liste : « Votre prochain rendez-vous » doit être un vrai prochain
+  // rendez-vous, pas un « Date à définir ».
   const aVenir = rdvs
     .filter(
       (r) =>
         r.principal.status !== "annule" && (!r.fin || new Date(r.fin).getTime() >= now)
     )
-    .reverse(); // le plus proche en premier
+    .sort((a, b) => {
+      if (!a.debut) return 1;
+      if (!b.debut) return -1;
+      return a.debut.localeCompare(b.debut); // le plus proche en premier
+    });
   const passes = rdvs.filter(
     (r) =>
       r.principal.status === "annule" || (r.fin != null && new Date(r.fin).getTime() < now)
@@ -314,7 +320,7 @@ export default function ClientAccount() {
               Demander un devis gratuit
             </Link>
             <Link href="/#chantier" className="btn-secondary flex-1 text-center">
-              Réserver un chantier
+              Rendez-vous chantier
             </Link>
           </div>
 


### PR DESCRIPTION
- Le second bouton de l'espace client s'intitule **« Rendez-vous chantier »**
  au lieu de « Réserver un chantier » (demande du client).
- Un rendez-vous **« Date à définir »** (devis créé à la main par le gérant)
  passait devant les rendez-vous datés et s'affichait donc comme
  **« Votre prochain rendez-vous »**, ce qui n'a pas de sens. Il reste dans les
  rendez-vous à venir mais en fin de liste.

Vérifié avec un compte de test comportant une visite dans 2 jours, une visite
« devis envoyé », un chantier de 3 jours et un devis sans date : la mise en avant
tombe bien sur la visite du 14 août, le « Date à définir » ferme la liste.

`npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_