### PR TITLE
Espace gérant : cloche de notifications

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -79,6 +79,8 @@ model Settings {
   googleTokenExpiry  DateTime?
   googleCalendarId   String  @default("primary")
   googleEmail        String  @default("")
+  // Cloche de notifications : tout ce qui date d'après ce moment est « non lu ».
+  notificationsSeenAt DateTime?
   updatedAt         DateTime @updatedAt
 }
 

--- a/app/src/app/admin/AdminNav.tsx
+++ b/app/src/app/admin/AdminNav.tsx
@@ -5,6 +5,7 @@
 // Sur mobile, seules les icônes restent visibles (rail étroit).
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
+import AdminNotifications from "./AdminNotifications";
 
 const ICONS: Record<string, JSX.Element> = {
   dashboard: (
@@ -125,9 +126,10 @@ export default function AdminNav() {
 
   return (
     <aside className="sticky top-0 flex h-screen w-14 shrink-0 flex-col border-r border-leaf-100 bg-white print:hidden sm:w-56">
-      <div className="flex items-center justify-center px-2 py-4 sm:justify-start sm:px-4">
+      <div className="flex flex-col items-center gap-2 px-2 py-4 sm:flex-row sm:justify-between sm:px-4">
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src="/logo.png" alt="Arboris Paysage" className="h-9 w-auto max-w-full object-contain" />
+        <AdminNotifications />
       </div>
 
       <nav className="flex flex-1 flex-col gap-1 px-2 py-2">

--- a/app/src/app/admin/AdminNotifications.tsx
+++ b/app/src/app/admin/AdminNotifications.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+// Cloche de notifications du gérant : pastille rouge dans la barre latérale,
+// panneau glissant à droite. Ce qui attend une action (chantier à attribuer,
+// relance à faire) apparaît au même endroit que ce qui vient d'arriver.
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+
+type Notification = {
+  id: string;
+  type: "rdv" | "lead" | "attribuer" | "rapport" | "relance" | "annule";
+  titre: string;
+  texte: string;
+  date: string;
+  lien: string;
+  lue: boolean;
+};
+
+const ICONES: Record<Notification["type"], JSX.Element> = {
+  rdv: (
+    <>
+      <rect x="3" y="4" width="18" height="18" rx="2" />
+      <path d="M8 2v4M16 2v4M3 10h18" />
+    </>
+  ),
+  lead: (
+    <>
+      <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
+      <circle cx="9" cy="7" r="4" />
+      <path d="M19 8v6M22 11h-6" />
+    </>
+  ),
+  attribuer: (
+    <>
+      <path d="M12 9v4M12 17h.01" />
+      <path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0z" />
+    </>
+  ),
+  rapport: (
+    <>
+      <path d="M9 3h6a1 1 0 0 1 1 1v2H8V4a1 1 0 0 1 1-1z" />
+      <path d="M16 5h2a2 2 0 0 1 2 2v12a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V7a2 2 0 0 1 2-2h2" />
+      <path d="m9 13 2 2 4-4" />
+    </>
+  ),
+  relance: (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="M12 7v5l3 3" />
+    </>
+  ),
+  annule: (
+    <>
+      <circle cx="12" cy="12" r="9" />
+      <path d="m15 9-6 6M9 9l6 6" />
+    </>
+  ),
+};
+
+// Ce qui réclame une action porte une couleur d'alerte ; le reste est neutre.
+const TONS: Record<Notification["type"], string> = {
+  rdv: "bg-leaf-50 text-leaf-700",
+  lead: "bg-blue-50 text-blue-700",
+  attribuer: "bg-amber-50 text-amber-700",
+  rapport: "bg-leaf-50 text-leaf-700",
+  relance: "bg-amber-50 text-amber-700",
+  annule: "bg-red-50 text-red-600",
+};
+
+function quand(iso: string): string {
+  const d = new Date(iso);
+  const minutes = Math.round((Date.now() - d.getTime()) / 60000);
+  if (minutes < 1) return "à l'instant";
+  if (minutes < 60) return `il y a ${minutes} min`;
+  if (minutes < 24 * 60) return `il y a ${Math.round(minutes / 60)} h`;
+  return d.toLocaleDateString("fr-FR", {
+    timeZone: "Europe/Paris",
+    day: "2-digit",
+    month: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function AdminNotifications() {
+  const [ouvert, setOuvert] = useState(false);
+  const [items, setItems] = useState<Notification[]>([]);
+  const [nonLues, setNonLues] = useState(0);
+  const [charge, setCharge] = useState(false);
+
+  const charger = useCallback(() => {
+    fetch("/api/admin/notifications")
+      .then((r) => (r.ok ? r.json() : { notifications: [], nonLues: 0 }))
+      .then((d) => {
+        setItems(d.notifications ?? []);
+        setNonLues(d.nonLues ?? 0);
+      })
+      .catch(() => {})
+      .finally(() => setCharge(true));
+  }, []);
+
+  useEffect(() => {
+    charger();
+    // Rafraîchissement discret : le gérant laisse souvent l'onglet ouvert.
+    const t = setInterval(charger, 120000);
+    return () => clearInterval(t);
+  }, [charger]);
+
+  // Échap ferme le panneau, comme partout ailleurs.
+  useEffect(() => {
+    if (!ouvert) return;
+    const h = (e: KeyboardEvent) => e.key === "Escape" && setOuvert(false);
+    window.addEventListener("keydown", h);
+    return () => window.removeEventListener("keydown", h);
+  }, [ouvert]);
+
+  async function toutLire() {
+    await fetch("/api/admin/notifications", { method: "POST" });
+    setItems((l) => l.map((n) => ({ ...n, lue: true })));
+    setNonLues(0);
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setOuvert(true)}
+        title="Notifications"
+        aria-label={nonLues > 0 ? `Notifications, ${nonLues} non lues` : "Notifications"}
+        className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-xl text-leaf-800/70 transition hover:bg-leaf-50 hover:text-leaf-900"
+      >
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-5 w-5">
+          <path d="M18 8a6 6 0 0 0-12 0c0 7-3 9-3 9h18s-3-2-3-9" />
+          <path d="M13.7 21a2 2 0 0 1-3.4 0" />
+        </svg>
+        {nonLues > 0 && (
+          <span className="absolute -right-0.5 -top-0.5 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-red-500 px-1 text-[11px] font-bold text-white">
+            {nonLues > 9 ? "9+" : nonLues}
+          </span>
+        )}
+      </button>
+
+      {ouvert && (
+        <>
+          <button
+            className="fixed inset-0 z-40 bg-black/20"
+            onClick={() => setOuvert(false)}
+            aria-label="Fermer les notifications"
+          />
+          <aside className="fixed right-0 top-0 z-50 flex h-screen w-full max-w-sm flex-col border-l border-leaf-100 bg-white shadow-xl">
+            <div className="flex items-start justify-between gap-2 border-b border-leaf-100 px-4 py-4">
+              <div>
+                <h2 className="text-lg font-bold">Notifications</h2>
+                <p className="text-sm text-leaf-800/60">
+                  {nonLues > 0 ? `${nonLues} non lue${nonLues > 1 ? "s" : ""}` : "Tout est à jour"}
+                </p>
+              </div>
+              <div className="flex items-center gap-3">
+                {nonLues > 0 && (
+                  <button onClick={toutLire} className="text-sm font-semibold text-leaf-700 underline">
+                    Tout marquer comme lu
+                  </button>
+                )}
+                <button
+                  onClick={() => setOuvert(false)}
+                  aria-label="Fermer"
+                  className="text-2xl leading-none text-leaf-800/50 hover:text-leaf-900"
+                >
+                  ×
+                </button>
+              </div>
+            </div>
+
+            <div className="flex-1 overflow-y-auto">
+              {!charge && <p className="p-6 text-center text-sm text-leaf-800/60">Chargement…</p>}
+              {charge && items.length === 0 && (
+                <p className="p-6 text-center text-sm text-leaf-800/60">
+                  Rien de nouveau. Les réservations, prospects, rapports de chantier et
+                  relances à faire apparaîtront ici.
+                </p>
+              )}
+              {items.map((n) => (
+                <Link
+                  key={n.id}
+                  href={n.lien}
+                  onClick={() => setOuvert(false)}
+                  className={`flex gap-3 border-b border-leaf-50 px-4 py-3 transition hover:bg-leaf-50/60 ${
+                    n.lue ? "" : "bg-leaf-50/30"
+                  }`}
+                >
+                  <span className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-xl ${TONS[n.type]}`}>
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" className="h-[18px] w-[18px]">
+                      {ICONES[n.type]}
+                    </svg>
+                  </span>
+                  <span className="min-w-0 flex-1">
+                    <span className="flex items-center gap-1.5">
+                      <span className="font-semibold text-leaf-900">{n.titre}</span>
+                      {!n.lue && <span className="h-2 w-2 shrink-0 rounded-full bg-leaf-600" />}
+                    </span>
+                    <span className="block text-sm text-leaf-800/75">{n.texte}</span>
+                    <span className="block text-xs text-leaf-800/50">{quand(n.date)}</span>
+                  </span>
+                </Link>
+              ))}
+            </div>
+          </aside>
+        </>
+      )}
+    </>
+  );
+}

--- a/app/src/app/api/admin/notifications/route.ts
+++ b/app/src/app/api/admin/notifications/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { isAdminAuthenticated } from "@/lib/auth";
+import { listerNotifications, marquerToutLu } from "@/lib/notificationsAdmin";
+
+export const dynamic = "force-dynamic";
+
+/** GET /api/admin/notifications — la cloche : ce qui attend le gérant. */
+export async function GET() {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  return NextResponse.json(await listerNotifications());
+}
+
+/** POST /api/admin/notifications — « Tout marquer comme lu ». */
+export async function POST() {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  await marquerToutLu();
+  return NextResponse.json({ ok: true });
+}

--- a/app/src/lib/notificationsAdmin.ts
+++ b/app/src/lib/notificationsAdmin.ts
@@ -1,0 +1,197 @@
+// Cloche de notifications du gérant.
+//
+// Rien n'est stocké : la liste est reconstruite à chaque ouverture à partir de
+// ce qui existe déjà (rendez-vous, prospects, rapports de chantier, affaires).
+// Un journal de notifications aurait imposé d'écrire à chaque événement — et
+// n'aurait rien montré de ce qui s'est passé avant sa mise en place.
+//
+// « Lu » = daté d'avant `Settings.notificationsSeenAt`.
+import { prisma } from "@/lib/prisma";
+import { estActive } from "@/lib/pipeline";
+
+export type Notification = {
+  id: string;
+  /** Détermine l'icône et la couleur côté écran. */
+  type: "rdv" | "lead" | "attribuer" | "rapport" | "relance" | "annule";
+  titre: string;
+  texte: string;
+  date: string;
+  lien: string;
+  lue: boolean;
+};
+
+const MAX = 25;
+const FENETRE_JOURS = 21;
+
+function nomDe(b: { firstName: string; lastName: string }): string {
+  return `${b.firstName} ${b.lastName}`.trim() || "Client sans nom";
+}
+
+function jourFr(d: Date | null): string {
+  if (!d) return "date à définir";
+  return d.toLocaleDateString("fr-FR", {
+    timeZone: "Europe/Paris",
+    day: "numeric",
+    month: "long",
+  });
+}
+
+export async function listerNotifications(): Promise<{
+  notifications: Notification[];
+  nonLues: number;
+}> {
+  const settings = await prisma.settings.findFirst();
+  const vuA = settings?.notificationsSeenAt ?? null;
+  const depuis = new Date(Date.now() - FENETRE_JOURS * 86400000);
+  const maintenant = new Date();
+  const items: Omit<Notification, "lue">[] = [];
+
+  // 1. Chantiers à venir sans paysagiste attribué : le plus urgent de la liste.
+  const aAttribuer = await prisma.booking.findMany({
+    where: {
+      kind: "chantier", proId: null, status: { not: "annule" },
+      startAt: { gte: maintenant },
+    },
+    orderBy: { startAt: "asc" },
+    take: MAX,
+    select: { id: true, createdAt: true, firstName: true, lastName: true, city: true, startAt: true },
+  });
+  for (const b of aAttribuer) {
+    items.push({
+      id: `attribuer-${b.id}`,
+      type: "attribuer",
+      titre: "Chantier à attribuer",
+      texte: `${nomDe(b)}${b.city ? ` — ${b.city}` : ""}, le ${jourFr(b.startAt)} : aucun paysagiste disponible`,
+      date: b.createdAt.toISOString(),
+      lien: "/admin/rendez-vous",
+    });
+  }
+  const dejaSignales = new Set(aAttribuer.map((b) => b.id));
+
+  // 2. Réservations reçues sur le site. Un chantier déjà signalé « à attribuer »
+  // n'est pas annoncé deux fois : la ligne d'alerte dit déjà qu'il est arrivé.
+  const nouveaux = await prisma.booking.findMany({
+    where: { source: "web", createdAt: { gte: depuis }, status: { not: "annule" } },
+    orderBy: { createdAt: "desc" },
+    take: MAX,
+    select: {
+      id: true, createdAt: true, kind: true, firstName: true, lastName: true,
+      city: true, startAt: true,
+    },
+  });
+  for (const b of nouveaux) {
+    if (dejaSignales.has(b.id)) continue;
+    items.push({
+      id: `rdv-${b.id}`,
+      type: "rdv",
+      titre: b.kind === "chantier" ? "Nouveau chantier réservé" : "Nouvelle visite de devis",
+      texte: `${nomDe(b)}${b.city ? ` — ${b.city}` : ""}, le ${jourFr(b.startAt)}`,
+      date: b.createdAt.toISOString(),
+      lien: "/admin/rendez-vous",
+    });
+  }
+
+  // 3. Prospects (formulaire hors zone, publicités Meta).
+  const leads = await prisma.lead.findMany({
+    where: { createdAt: { gte: depuis } },
+    orderBy: { createdAt: "desc" },
+    take: MAX,
+    select: { id: true, createdAt: true, name: true, postalCode: true, source: true },
+  });
+  for (const l of leads) {
+    items.push({
+      id: `lead-${l.id}`,
+      type: "lead",
+      titre: l.source === "meta" ? "Nouveau prospect (publicité)" : "Nouveau prospect",
+      texte: `${l.name || "Sans nom"}${l.postalCode ? ` — ${l.postalCode}` : ""}`,
+      date: l.createdAt.toISOString(),
+      lien: "/admin/clients",
+    });
+  }
+
+  // 4. Rapports de chantier remplis par les paysagistes, pas encore validés.
+  const rapports = await prisma.workEntry.findMany({
+    where: {
+      validated: false,
+      updatedAt: { gte: depuis },
+      NOT: [{ photosBeforeJson: "[]" }, { photosAfterJson: "[]" }],
+    },
+    orderBy: { updatedAt: "desc" },
+    take: MAX,
+    select: { id: true, updatedAt: true, date: true, pro: { select: { name: true } } },
+  });
+  for (const r of rapports) {
+    items.push({
+      id: `rapport-${r.id}`,
+      type: "rapport",
+      titre: "Rapport de chantier à valider",
+      texte: `${r.pro?.name ?? "Un paysagiste"} a ajouté des photos pour le ${jourFr(
+        new Date(`${r.date}T12:00:00Z`)
+      )}`,
+      date: r.updatedAt.toISOString(),
+      lien: "/admin/chantiers",
+    });
+  }
+
+  // 5. Affaires dont la prochaine action est arrivée à échéance.
+  const relances = await prisma.affaire.findMany({
+    where: { prochaineActionAt: { lte: maintenant } },
+    orderBy: { prochaineActionAt: "asc" },
+    take: MAX,
+    select: {
+      id: true, intitule: true, statut: true, prochaineActionAt: true,
+      contact: { select: { firstName: true, lastName: true } },
+    },
+  });
+  for (const a of relances) {
+    if (!estActive(a.statut) || !a.prochaineActionAt) continue;
+    items.push({
+      id: `relance-${a.id}`,
+      type: "relance",
+      titre: "Relance à faire",
+      texte: `${nomDe(a.contact)} — ${a.intitule || "affaire en cours"}, prévue le ${jourFr(
+        a.prochaineActionAt
+      )}`,
+      date: a.prochaineActionAt.toISOString(),
+      lien: "/admin/affaires",
+    });
+  }
+
+  // 6. Annulations : un créneau se libère, et parfois un client à rappeler.
+  const annules = await prisma.booking.findMany({
+    where: { status: "annule", cancelledAt: { gte: depuis } },
+    orderBy: { cancelledAt: "desc" },
+    take: MAX,
+    select: {
+      id: true, cancelledAt: true, kind: true, firstName: true, lastName: true, startAt: true,
+    },
+  });
+  for (const b of annules) {
+    if (!b.cancelledAt) continue;
+    items.push({
+      id: `annule-${b.id}`,
+      type: "annule",
+      titre: b.kind === "chantier" ? "Chantier annulé" : "Visite annulée",
+      texte: `${nomDe(b)} — créneau du ${jourFr(b.startAt)} libéré`,
+      date: b.cancelledAt.toISOString(),
+      lien: "/admin/rendez-vous",
+    });
+  }
+
+  const notifications = items
+    .sort((a, b) => b.date.localeCompare(a.date))
+    .slice(0, MAX)
+    .map((n) => ({ ...n, lue: vuA != null && new Date(n.date) <= vuA }));
+
+  return { notifications, nonLues: notifications.filter((n) => !n.lue).length };
+}
+
+/** « Tout marquer comme lu ». */
+export async function marquerToutLu(): Promise<void> {
+  const settings = await prisma.settings.findFirst();
+  if (!settings) return;
+  await prisma.settings.update({
+    where: { id: settings.id },
+    data: { notificationsSeenAt: new Date() },
+  });
+}


### PR DESCRIPTION
Cloche dans la barre latérale avec pastille rouge du nombre de non-lues, et
panneau glissant à droite — sur le modèle de la maquette fournie par le client.

## Six sources, tirées des données existantes

Aucun journal de notifications n'est stocké : la liste est reconstruite à chaque
ouverture. Un journal aurait imposé d'écrire à chaque événement et n'aurait rien
montré de ce qui s'est passé avant sa mise en place.

| Notification | Origine | Mène vers |
|---|---|---|
| **Chantier à attribuer** (orange) | chantier à venir sans paysagiste | Rendez-vous |
| Nouvelle visite / nouveau chantier | réservation sur le site | Rendez-vous |
| Nouveau prospect | `Lead` (formulaire hors zone, publicités Meta) | Tous les clients |
| Rapport de chantier à valider | `WorkEntry` avec photos, non validé | Chantiers |
| **Relance à faire** (orange) | affaire active dont `prochaineActionAt` est échue | Affaires |
| Rendez-vous annulé | annulation récente | Rendez-vous |

Un chantier déjà signalé « à attribuer » n'est pas annoncé une seconde fois
comme « nouveau chantier réservé ».

## Lu / non lu

Un seul champ ajouté : `Settings.notificationsSeenAt` (nullable). Tout ce qui est
postérieur est non lu ; « Tout marquer comme lu » l'horodate à maintenant. Pas de
table supplémentaire, pas de migration risquée.

Le panneau se ferme par la croix, par l'arrière-plan ou par Échap ; un clic sur
une ligne mène à l'écran concerné. Rafraîchissement automatique toutes les
2 minutes, l'onglet du gérant restant souvent ouvert.

## Vérifications

Jeu de test avec une donnée par source :

- pastille à **6**, six lignes dans le bon ordre chronologique ;
- le chantier sans paysagiste apparaît une seule fois, en orange ;
- « Tout marquer comme lu » → pastille vide, entête « Tout est à jour », état
  conservé après rechargement ;
- Échap ferme le panneau ; rendu vérifié en rail mobile.

`npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_