### PR TITLE
Agenda : ajouter un rendez-vous en cliquant sur un créneau

### DIFF
--- a/app/src/app/admin/ManualBookingModal.tsx
+++ b/app/src/app/admin/ManualBookingModal.tsx
@@ -1,25 +1,35 @@
 "use client";
 
-// Modale « Ajouter un devis manuellement » : tous les champs sont optionnels
-// (client au téléphone, prospect croisé sur un chantier…).
+// Modale « Ajouter un rendez-vous » : tous les champs sont optionnels (client au
+// téléphone, prospect croisé sur un chantier, créneau posé depuis l'agenda…).
+// Ouverte depuis l'agenda, elle arrive avec le jour et l'heure déjà remplis.
 import { useState } from "react";
 import AddressAutocomplete, { type AddressValue } from "@/components/AddressAutocomplete";
 import PhotoUpload from "@/components/PhotoUpload";
+import { PROJECT_LABELS } from "@/lib/rdvLabels";
 
 export default function ManualBookingModal({
   onClose,
   onCreated,
+  defaultDateTime = "",
+  defaultKind = "devis",
 }: {
   onClose: () => void;
   onCreated: () => void;
+  /** « AAAA-MM-JJTHH:mm », tel que l'attend un champ datetime-local. */
+  defaultDateTime?: string;
+  defaultKind?: "devis" | "chantier";
 }) {
+  const [kind, setKind] = useState<"devis" | "chantier">(defaultKind);
+  const [formule, setFormule] = useState<"demi" | "journee">("journee");
+  const [projectType, setProjectType] = useState("autre");
   const [firstName, setFirstName] = useState("");
   const [lastName, setLastName] = useState("");
   const [phone, setPhone] = useState("");
   const [email, setEmail] = useState("");
   const [addr, setAddr] = useState<AddressValue>({ address: "", postalCode: "", city: "" });
   const [description, setDescription] = useState("");
-  const [dateTime, setDateTime] = useState("");
+  const [dateTime, setDateTime] = useState(defaultDateTime);
   const [photos, setPhotos] = useState<string[]>([]);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
@@ -34,6 +44,9 @@ export default function ManualBookingModal({
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
+          kind,
+          formule,
+          projectType,
           firstName,
           lastName,
           phone,
@@ -60,12 +73,24 @@ export default function ManualBookingModal({
     }
   }
 
+  const onglet = (id: "devis" | "chantier", label: string) => (
+    <button
+      type="button"
+      onClick={() => setKind(id)}
+      className={`flex-1 rounded-lg px-3 py-2 text-sm font-semibold transition ${
+        kind === id ? "bg-white text-leaf-900 shadow-sm" : "text-leaf-800/60"
+      }`}
+    >
+      {label}
+    </button>
+  );
+
   return (
     <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/40 p-4">
       <form onSubmit={submit} className="card my-6 w-full max-w-lg space-y-4">
         <div className="flex items-start justify-between">
           <div>
-            <h2 className="text-lg font-bold">Ajouter un devis manuellement</h2>
+            <h2 className="text-lg font-bold">Ajouter un rendez-vous</h2>
             <p className="text-sm text-leaf-800/60">
               Tous les champs sont facultatifs — notez ce que vous savez.
             </p>
@@ -73,6 +98,11 @@ export default function ManualBookingModal({
           <button type="button" onClick={onClose} aria-label="Fermer" className="text-xl text-leaf-800/50">
             ✕
           </button>
+        </div>
+
+        <div className="flex rounded-xl bg-leaf-50 p-1">
+          {onglet("devis", "Visite de devis")}
+          {onglet("chantier", "Chantier")}
         </div>
 
         <div className="grid grid-cols-2 gap-3">
@@ -97,6 +127,21 @@ export default function ManualBookingModal({
         </div>
         <AddressAutocomplete value={addr} onChange={setAddr} label="Adresse" optional />
         <div>
+          <label className="label" htmlFor="m-prestation">Prestation</label>
+          <select
+            id="m-prestation"
+            className="input"
+            value={projectType}
+            onChange={(e) => setProjectType(e.target.value)}
+          >
+            {Object.entries(PROJECT_LABELS).map(([id, label]) => (
+              <option key={id} value={id}>
+                {label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div>
           <label className="label" htmlFor="m-notes">Notes</label>
           <textarea
             id="m-notes"
@@ -107,7 +152,9 @@ export default function ManualBookingModal({
           />
         </div>
         <div>
-          <label className="label" htmlFor="m-date">Rendez-vous (facultatif)</label>
+          <label className="label" htmlFor="m-date">
+            Date et heure {kind === "devis" && "(facultatif)"}
+          </label>
           <input
             id="m-date"
             className="input"
@@ -115,11 +162,50 @@ export default function ManualBookingModal({
             value={dateTime}
             onChange={(e) => setDateTime(e.target.value)}
           />
-          <p className="mt-1 text-xs text-leaf-800/60">
-            Laissez vide : le devis restera « sans date » en attendant.
-          </p>
+          {kind === "devis" ? (
+            <p className="mt-1 text-xs text-leaf-800/60">
+              Laissez vide : le devis restera « sans date » en attendant.
+            </p>
+          ) : (
+            <p className="mt-1 text-xs text-leaf-800/60">
+              Sans date, le chantier n&apos;apparaîtra pas dans l&apos;agenda.
+            </p>
+          )}
         </div>
+        {kind === "chantier" && (
+          <div>
+            <span className="label">Durée</span>
+            <div className="mt-1 flex gap-2">
+              {(
+                [
+                  ["demi", "Demi-journée (4 h)"],
+                  ["journee", "Journée entière (8 h)"],
+                ] as const
+              ).map(([id, label]) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => setFormule(id)}
+                  className={`flex-1 rounded-xl border px-3 py-2 text-sm font-semibold transition ${
+                    formule === id
+                      ? "border-leaf-600 bg-leaf-50 text-leaf-800"
+                      : "border-leaf-200 text-leaf-800/60"
+                  }`}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
         <PhotoUpload photos={photos} onChange={setPhotos} label="Photos (10 max)" maxPhotos={10} />
+
+        {kind === "chantier" && (
+          <p className="rounded-xl bg-leaf-50 px-3 py-2 text-sm text-leaf-800/80">
+            Un chantier ajouté à la main n&apos;est attribué à personne : il apparaît en orange
+            « À attribuer », et vous choisissez le paysagiste depuis sa fiche.
+          </p>
+        )}
 
         {error && <p className="text-sm text-red-600">{error}</p>}
         <div className="flex flex-col gap-2 sm:flex-row">
@@ -127,7 +213,7 @@ export default function ManualBookingModal({
             Annuler
           </button>
           <button className="btn-primary" disabled={busy}>
-            {busy ? "Création…" : "Créer le devis"}
+            {busy ? "Création…" : "Créer le rendez-vous"}
           </button>
         </div>
       </form>

--- a/app/src/app/admin/planning/page.tsx
+++ b/app/src/app/admin/planning/page.tsx
@@ -1,12 +1,34 @@
 "use client";
 
 // Planning patron : agenda partagé, avec les coordonnées (téléphones) visibles.
+// Un clic sur une plage libre ouvre la création d'un rendez-vous à cette heure.
+import { useState } from "react";
 import AgendaView from "@/components/AgendaView";
+import ManualBookingModal from "../ManualBookingModal";
 
 export default function PlanningPage() {
+  const [creneau, setCreneau] = useState<string | null>(null);
+  const [refresh, setRefresh] = useState(0);
+
   return (
     <main className="mx-auto max-w-6xl px-4 py-6">
-      <AgendaView endpoint="/api/admin/planning" loginPath="/admin/login" showContacts />
+      <AgendaView
+        endpoint="/api/admin/planning"
+        loginPath="/admin/login"
+        showContacts
+        refreshToken={refresh}
+        onCreneau={(jour, heure) => setCreneau(`${jour}T${heure}`)}
+      />
+      {creneau && (
+        <ManualBookingModal
+          defaultDateTime={creneau}
+          onClose={() => setCreneau(null)}
+          onCreated={() => {
+            setCreneau(null);
+            setRefresh((n) => n + 1);
+          }}
+        />
+      )}
     </main>
   );
 }

--- a/app/src/app/admin/rendez-vous/page.tsx
+++ b/app/src/app/admin/rendez-vous/page.tsx
@@ -248,7 +248,7 @@ export default function AdminDashboard() {
             Annulés
           </label>
           <button className="btn-primary !w-auto !px-4 !py-2.5 text-sm" onClick={() => setShowModal(true)}>
-            Ajouter un devis manuellement
+            Ajouter un rendez-vous
           </button>
         </div>
       </div>

--- a/app/src/app/api/admin/bookings/route.ts
+++ b/app/src/app/api/admin/bookings/route.ts
@@ -91,9 +91,14 @@ function cleanPhotos(v: unknown): string[] {
     .slice(0, 10);
 }
 
-// POST /api/admin/bookings — devis créé à la main par le gérant (client au
-// téléphone, prospect rencontré sur place…). Tous les champs sont optionnels ;
-// sans date choisie, le devis reste « sans date » (startAt null).
+/** Durée d'un jour de chantier posé à la main, en minutes. */
+const CHANTIER_MIN: Record<string, number> = { demi: 4 * 60, journee: 8 * 60 };
+const PROJECT_TYPES = ["entretien", "taille_haie", "debroussaillage", "contrat_annuel", "autre"];
+
+// POST /api/admin/bookings — rendez-vous créé à la main par le gérant (client au
+// téléphone, prospect rencontré sur place, créneau posé depuis l'agenda…). Tous
+// les champs sont optionnels ; sans date choisie, il reste « sans date »
+// (startAt null). `kind` vaut « devis » (défaut) ou « chantier ».
 export async function POST(req: NextRequest) {
   if (!isAdminAuthenticated()) {
     return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
@@ -115,6 +120,9 @@ export async function POST(req: NextRequest) {
   const description = s("description");
   const dateKey = s("date"); // AAAA-MM-JJ (facultatif)
   const time = s("time"); // HH:mm (facultatif)
+  const kind = s("kind") === "chantier" ? "chantier" : "devis";
+  const formule = s("formule") === "journee" ? "journee" : "demi";
+  const projectType = PROJECT_TYPES.includes(s("projectType")) ? s("projectType") : "autre";
   const photos = cleanPhotos(body.photos);
 
   // Garde-fou : au moins une information.
@@ -140,7 +148,9 @@ export async function POST(req: NextRequest) {
     }
     const settings = await getSettings();
     startAt = parisTimeToUtc(dateKey, time);
-    endAt = new Date(startAt.getTime() + settings.visitDurationMin * 60_000);
+    const minutes =
+      kind === "chantier" ? CHANTIER_MIN[formule] : settings.visitDurationMin;
+    endAt = new Date(startAt.getTime() + minutes * 60_000);
   }
 
   // Fiche client : un devis saisi au téléphone doit lui aussi entrer dans la
@@ -170,9 +180,9 @@ export async function POST(req: NextRequest) {
       postalCode,
       city,
       description,
-      kind: "devis",
+      kind,
       source: "manual",
-      projectType: "autre",
+      projectType,
       startAt,
       endAt,
       photos: { create: photos.map((dataUrl) => ({ dataUrl })) },
@@ -183,8 +193,9 @@ export async function POST(req: NextRequest) {
     await affairePourRdv({ ...booking, proId: null });
     await journaliser(
       contact.id,
-      "devis",
-      description || "Devis créé à la main depuis le tableau de bord.",
+      kind === "chantier" ? "rdv" : "devis",
+      description ||
+        `${kind === "chantier" ? "Chantier" : "Devis"} créé à la main depuis l'espace gérant.`,
       { sens: "interne", auteur: "gerant" }
     );
   }

--- a/app/src/components/AgendaView.tsx
+++ b/app/src/components/AgendaView.tsx
@@ -108,10 +108,21 @@ export default function AgendaView({
   endpoint,
   loginPath,
   showContacts = false,
+  onCreneau,
+  refreshToken = 0,
 }: {
   endpoint: string;
   loginPath: string;
   showContacts?: boolean;
+  /**
+   * Fourni par l'espace gérant : un clic sur une zone libre de la grille
+   * horaire remonte le jour et l'heure (arrondie à la demi-heure) pour ouvrir
+   * la création de rendez-vous. Absent ailleurs (espace pro) : l'agenda reste
+   * en lecture seule.
+   */
+  onCreneau?: (dateKey: string, heure: string) => void;
+  /** Incrémenter cette valeur recharge l'agenda (après une création). */
+  refreshToken?: number;
 }) {
   const [view, setView] = useState<View>("semaine");
   const [refDate, setRefDate] = useState(() => {
@@ -159,7 +170,7 @@ export default function AgendaView({
       })
       .finally(() => setLoading(false));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [view, refDate]);
+  }, [view, refDate, refreshToken]);
 
   // Encart « Aujourd'hui » : toujours alimenté, quelle que soit la période affichée
   useEffect(() => {
@@ -168,7 +179,7 @@ export default function AgendaView({
       .then((data) => setTodayBookings(data?.bookings ?? []))
       .catch(() => {});
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [refreshToken]);
 
   /** Les RDV retenus par le filtre « qui ». */
   const bookingsVisibles = useMemo(() => {
@@ -349,7 +360,29 @@ export default function AgendaView({
               return (
                 <div
                   key={day}
-                  className="relative border-l border-leaf-100"
+                  onClick={
+                    onCreneau
+                      ? (e) => {
+                          // Position du clic dans la colonne → heure, arrondie
+                          // à la demi-heure comme les créneaux du site.
+                          const rect = e.currentTarget.getBoundingClientRect();
+                          const minutes =
+                            HOUR_START * 60 + ((e.clientY - rect.top) / HOUR_PX) * 60;
+                          const cale = Math.max(
+                            HOUR_START * 60,
+                            Math.floor(minutes / 30) * 30
+                          );
+                          onCreneau(
+                            day,
+                            `${pad(Math.floor(cale / 60))}:${pad(cale % 60)}`
+                          );
+                        }
+                      : undefined
+                  }
+                  title={onCreneau ? "Cliquez pour ajouter un rendez-vous" : undefined}
+                  className={`relative border-l border-leaf-100 ${
+                    onCreneau ? "cursor-copy" : ""
+                  }`}
                   style={{ height: hours.length * HOUR_PX }}
                 >
                   {hours.map((h, i) => (
@@ -378,7 +411,12 @@ export default function AgendaView({
                     return (
                       <button
                         key={b.id}
-                        onClick={() => setSelected(day)}
+                        onClick={(e) => {
+                          // Sans cela, le clic sur un RDV créerait aussi un
+                          // créneau libre dans la colonne qui le porte.
+                          e.stopPropagation();
+                          setSelected(day);
+                        }}
                         title={`${plage} · ${b.firstName} ${b.lastName}${aAttribuer ? " · À ATTRIBUER" : ""}`}
                         className={`absolute overflow-hidden rounded-lg text-left font-semibold leading-tight text-white shadow-sm ${
                           etroit
@@ -432,12 +470,27 @@ export default function AgendaView({
   return (
     <div>
       <div className="mb-4 flex flex-wrap items-center justify-between gap-3">
-        <h1 className="text-xl font-bold">Agenda</h1>
+        <div>
+          <h1 className="text-xl font-bold">Agenda</h1>
+          {onCreneau && (
+            <p className="text-sm text-leaf-800/60">
+              Cliquez sur une plage horaire libre pour ajouter un rendez-vous.
+            </p>
+          )}
+        </div>
         <div className="flex flex-wrap items-center gap-2">
+          {onCreneau && (
+            <button
+              className="btn-primary !px-3 !py-1.5 text-sm"
+              onClick={() => onCreneau(days[0] ?? todayKey, "09:00")}
+            >
+              + Rendez-vous
+            </button>
+          )}
           <button className="btn-secondary !px-3 !py-1.5" onClick={() => navigate(-1)}>←</button>
           <button className="btn-secondary !px-3 !py-1.5" onClick={goToday}>Aujourd&apos;hui</button>
           <button className="btn-secondary !px-3 !py-1.5" onClick={() => navigate(1)}>→</button>
-          <span className="min-w-[11rem] text-center text-sm font-semibold capitalize">{periodLabel}</span>
+          <span className="min-w-[11rem] text-center text-sm font-semibold first-letter:uppercase">{periodLabel}</span>
           <div className="flex rounded-xl bg-leaf-50 p-1">
             {(["mois", "semaine", "jour"] as View[]).map((v) => (
               <button


### PR DESCRIPTION
L'agenda du gérant était en lecture seule : la seule création manuelle possible
passait par le bouton « Ajouter un devis manuellement » du tableau de bord, et
elle ne créait que des **visites de devis**, jamais de chantiers.

## Ce qui change

- **Clic sur une plage libre de la grille** (vue Semaine ou Jour) → la modale de
  création s'ouvre avec **le jour et l'heure déjà remplis**, arrondis à la
  demi-heure comme les créneaux du site. Un bouton **« + Rendez-vous »** couvre
  la vue Mois et les habitués du clavier.
- Le clic sur un rendez-vous existant ouvre toujours son détail — il ne crée plus
  un créneau par ricochet (`stopPropagation`).
- **La modale gère les deux types** : onglets « Visite de devis » / « Chantier »,
  choix de la prestation, et pour un chantier **demi-journée (4 h) ou journée
  entière (8 h)**. Elle s'intitule désormais « Ajouter un rendez-vous ».
- `POST /api/admin/bookings` accepte `kind`, `formule` et `projectType`. La durée
  suit le type : durée de visite paramétrée pour un devis, 4 h ou 8 h pour un
  chantier.
- Un chantier ajouté à la main **n'est attribué à personne** : il apparaît en
  orange « À attribuer » et le gérant choisit le paysagiste depuis la fiche. La
  modale le dit explicitement — une attribution automatique silencieuse aurait
  envoyé un email à un paysagiste sans que le gérant l'ait décidé.
- L'agenda se rafraîchit tout seul après création (`refreshToken`).
- L'agenda de **l'espace pro reste en lecture seule** : il ne passe pas
  `onCreneau`, donc ni curseur, ni bouton, ni consigne.
- Au passage : « Semaine Du 10 Août 2026 » → « Semaine du 10 août 2026 »
  (`capitalize` mettait une majuscule à chaque mot).

## Vérifications

- Clic à mi-hauteur de la colonne du lundi → modale pré-remplie à **12:30** ce
  jour-là ;
- création d'un chantier demi-journée pour « Hélène Roux » → bloc **12h30–16h30**
  affiché immédiatement, en base : `kind: chantier`, `projectType: taille_haie`,
  `source: manual`, `proId: null` ;
- clic sur un rendez-vous existant → la modale de création ne s'ouvre pas ;
- côté pro : 0 colonne cliquable, 0 bouton, 0 consigne.

`npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_