### PR TITLE
Prospects : porte d'entrée Zapier / Make pour les leads Meta

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -72,6 +72,9 @@ model Settings {
   // Jeton de vérification à recopier dans le tableau de bord Meta
   metaVerifyToken   String   @default("")
   metaLeadsEnabled  Boolean  @default(true)
+  // Clé de la porte d'entrée « simple » : Zapier / Make y poste les prospects
+  // sans passer par la validation d'application Meta.
+  leadsApiKey       String   @default("")
   metaConnectedAt   DateTime?
   // Connexion Google Calendar (OAuth 2.0)
   googleRefreshToken String  @default("")

--- a/app/src/app/admin/meta/page.tsx
+++ b/app/src/app/admin/meta/page.tsx
@@ -31,6 +31,7 @@ type Status = {
   leadsEnabled: boolean;
   verifyToken: string;
   webhookUrl: string;
+  zapierUrl: string;
   leads: Lead[];
   aTraiter: number;
 };
@@ -116,6 +117,25 @@ export default function AdminMetaPage() {
       setAppSecret("");
       setInfo("Réglages enregistrés.");
     } else setErreur("Enregistrement impossible.");
+  }
+
+  /** Génère (ou régénère) la clé de la voie Zapier. */
+  async function cleZapier(rotate: boolean) {
+    if (rotate && !window.confirm(
+      "Générer une nouvelle clé ? L'ancienne adresse cessera de fonctionner : il faudra recoller la nouvelle dans Zapier."
+    )) return;
+    setBusy(true);
+    setErreur("");
+    const res = await fetch("/api/admin/meta", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ genererCleZapier: rotate ? "rotate" : true }),
+    });
+    setBusy(false);
+    if (res.ok) {
+      apply(await res.json());
+      setInfo("Adresse prête : collez-la dans Zapier ou Make.");
+    } else setErreur("Génération impossible.");
   }
 
   async function loadPages() {
@@ -335,6 +355,51 @@ export default function AdminMetaPage() {
           </p>
           <Copiable label="URL de rappel" value={s.webhookUrl} />
           <Copiable label="Jeton de vérification" value={s.verifyToken || "— enregistrez l'étape 1"} />
+        </section>
+
+        {/* Voie simple : Zapier / Make. Sans revue d'application Meta. */}
+        <section className="card space-y-3 border-2 border-leaf-200">
+          <div>
+            <h2 className="font-bold">La voie simple : Zapier ou Make</h2>
+            <p className="mt-1 text-sm text-leaf-800/70">
+              Les étapes 1 à 3 exigent que Meta valide votre application (revue et vérification
+              d&apos;entreprise), ce qui prend des semaines. Zapier et Make sont déjà validés par
+              Meta : ils reçoivent vos prospects tout de suite et les déposent ici.
+            </p>
+          </div>
+
+          {s.zapierUrl ? (
+            <>
+              <Copiable label="Adresse à coller dans Zapier (contient votre clé)" value={s.zapierUrl} />
+              <ol className="ml-5 list-decimal space-y-1 text-sm text-leaf-800/80">
+                <li>Sur zapier.com, créez un Zap.</li>
+                <li>
+                  Déclencheur : <b>Facebook Lead Ads</b> → <i>New Lead</i>, puis connectez votre page.
+                </li>
+                <li>
+                  Action : <b>Webhooks by Zapier</b> → <i>POST</i>. Collez l&apos;adresse ci-dessus dans
+                  <b> URL</b>, mettez <b>Payload Type : JSON</b>.
+                </li>
+                <li>
+                  Dans <b>Data</b>, ajoutez les lignes <code>name</code>, <code>phone</code>,{" "}
+                  <code>email</code>, <code>postal_code</code>, <code>message</code> et reliez-les aux
+                  champs de votre formulaire.
+                </li>
+                <li>Testez : le prospect apparaît aussitôt ci-dessous et vous recevez l&apos;alerte.</li>
+              </ol>
+              <p className="text-xs text-leaf-800/60">
+                Cette adresse ne permet que de déposer un prospect. Gardez-la pour vous ;
+                si elle circule, régénérez-la.
+              </p>
+              <button className="btn-secondary !w-auto !px-4 !py-2 text-sm" onClick={() => cleZapier(true)} disabled={busy}>
+                Générer une nouvelle adresse
+              </button>
+            </>
+          ) : (
+            <button className="btn-primary !w-auto !px-4 !py-2.5 text-sm" onClick={() => cleZapier(false)} disabled={busy}>
+              Créer mon adresse de réception
+            </button>
+          )}
         </section>
 
         {/* 4. Prospects reçus */}

--- a/app/src/app/api/admin/meta/route.ts
+++ b/app/src/app/api/admin/meta/route.ts
@@ -26,6 +26,11 @@ async function status() {
     leadsEnabled: s.metaLeadsEnabled,
     verifyToken: s.metaVerifyToken,
     webhookUrl: `${appUrl()}/api/meta/webhook`,
+    // Voie simple : l'adresse à coller dans Zapier / Make, clé comprise.
+    // La clé n'ouvre que le dépôt de prospects, rien d'autre.
+    zapierUrl: s.leadsApiKey
+      ? `${appUrl()}/api/leads/inbound?key=${s.leadsApiKey}`
+      : "",
     leads,
     aTraiter,
   };
@@ -64,6 +69,11 @@ export async function PUT(req: NextRequest) {
   // Le jeton de vérification du webhook est généré une fois pour toutes.
   const current = await getSettings();
   if (!current.metaVerifyToken) data.metaVerifyToken = crypto.randomBytes(16).toString("hex");
+
+  // Clé de la voie Zapier : générée à la demande, régénérable si elle fuite.
+  if (body.genererCleZapier === true || (body.genererCleZapier === "rotate" && current.leadsApiKey)) {
+    data.leadsApiKey = crypto.randomBytes(24).toString("hex");
+  }
 
   await prisma.settings.update({ where: { id: "main" }, data });
   return NextResponse.json(await status());

--- a/app/src/app/api/leads/inbound/route.ts
+++ b/app/src/app/api/leads/inbound/route.ts
@@ -1,0 +1,162 @@
+import { NextRequest, NextResponse } from "next/server";
+import crypto from "crypto";
+import { prisma } from "@/lib/prisma";
+import { getSettings } from "@/lib/settings";
+import { creerOuCompleterContact, journaliser, splitNom } from "@/lib/contacts";
+import { notifyOwnerNewLead } from "@/lib/notifications";
+
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+/**
+ * POST /api/leads/inbound — porte d'entrée « simple » pour les prospects.
+ *
+ * Pensée pour Zapier / Make branchés sur Facebook Lead Ads : ces services sont
+ * déjà des partenaires validés par Meta, donc ils reçoivent les prospects sans
+ * qu'on ait à faire valider notre propre application (« leads_retrieval »), ce
+ * qui demande une revue Meta et une vérification d'entreprise.
+ *
+ * Volontairement tolérante sur les noms de champs : chaque outil envoie ce
+ * qu'il veut, et un formulaire publicitaire français ne nomme pas ses champs
+ * comme un formulaire anglais.
+ */
+
+const ALIAS: Record<string, string[]> = {
+  name: ["name", "full_name", "fullname", "nom_complet", "nom complet", "nom"],
+  firstName: ["first_name", "firstname", "prenom", "prénom"],
+  lastName: ["last_name", "lastname", "nom_de_famille"],
+  phone: ["phone", "phone_number", "telephone", "téléphone", "tel", "numero", "numéro", "mobile"],
+  email: ["email", "e_mail", "mail", "courriel"],
+  postalCode: ["postalcode", "postal_code", "post_code", "postcode", "zip", "zip_code", "code_postal", "cp"],
+  message: ["message", "projet", "besoin", "commentaire", "precisions", "précisions", "demande"],
+  externalId: ["externalid", "external_id", "id", "leadgen_id", "lead_id"],
+  campaign: ["campaign", "campaign_name", "campagne"],
+  adName: ["ad_name", "adname", "publicite", "publicité", "ad"],
+  formName: ["form_name", "formname", "formulaire"],
+};
+
+/** Cherche une valeur quel que soit le libellé employé par l'outil source. */
+function champ(plat: Record<string, string>, cle: keyof typeof ALIAS): string {
+  for (const k of ALIAS[cle]) {
+    const v = plat[k];
+    if (v) return v.trim();
+  }
+  return "";
+}
+
+/** Aplatit l'objet reçu : Zapier imbrique volontiers ses champs. */
+function aplatir(v: unknown, out: Record<string, string> = {}, profondeur = 0): Record<string, string> {
+  if (profondeur > 4 || v === null || typeof v !== "object") return out;
+  for (const [k, val] of Object.entries(v as Record<string, unknown>)) {
+    const cle = k.toLowerCase().trim();
+    if (val === null || val === undefined) continue;
+    if (typeof val === "object") {
+      // field_data façon Meta : [{ name: "phone_number", values: ["06…"] }].
+      // On ne descend PAS dedans : ses clés « name » et « values » décrivent le
+      // champ, elles ne sont pas la réponse — on lisait « full_name » comme nom
+      // du prospect.
+      const o = val as Record<string, unknown>;
+      if (typeof o.name === "string" && Array.isArray(o.values)) {
+        out[o.name.toLowerCase()] = o.values.join(", ");
+        continue;
+      }
+      aplatir(val, out, profondeur + 1);
+    } else if (out[cle] === undefined) {
+      out[cle] = String(val);
+    }
+  }
+  return out;
+}
+
+export async function POST(req: NextRequest) {
+  const settings = await getSettings();
+  if (!settings.leadsApiKey) {
+    return NextResponse.json(
+      { error: "Réception désactivée : générez la clé dans Publicités Meta." },
+      { status: 503 }
+    );
+  }
+  const fournie =
+    req.nextUrl.searchParams.get("key") ??
+    req.headers.get("x-api-key") ??
+    (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "");
+  const attendue = Buffer.from(settings.leadsApiKey);
+  const donnee = Buffer.from(fournie ?? "");
+  if (attendue.length !== donnee.length || !crypto.timingSafeEqual(attendue, donnee)) {
+    return NextResponse.json({ error: "Clé invalide" }, { status: 401 });
+  }
+
+  let brut: unknown;
+  try {
+    brut = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+  const plat = aplatir(brut);
+
+  const prenom = champ(plat, "firstName");
+  const nom = champ(plat, "lastName");
+  const nomComplet = champ(plat, "name") || `${prenom} ${nom}`.trim();
+  const phone = champ(plat, "phone");
+  const email = champ(plat, "email");
+  if (!phone && !email) {
+    return NextResponse.json(
+      { error: "Un téléphone ou un email est nécessaire pour rappeler le prospect." },
+      { status: 400 }
+    );
+  }
+
+  // Sans identifiant fourni, on en fabrique un stable : un même prospect renvoyé
+  // le même jour (réessai de Zapier) ne crée pas de doublon.
+  const jour = new Date().toISOString().slice(0, 10);
+  const externalId =
+    champ(plat, "externalId") ||
+    "auto-" +
+      crypto
+        .createHash("sha256")
+        .update(`${phone}|${email}|${nomComplet}|${jour}`)
+        .digest("hex")
+        .slice(0, 24);
+
+  const existant = await prisma.lead.findFirst({ where: { externalId } });
+  if (existant) {
+    return NextResponse.json({ ok: true, duplicate: true, id: existant.id });
+  }
+
+  const message = champ(plat, "message");
+  const lead = await prisma.lead.create({
+    data: {
+      name: nomComplet || "Prospect",
+      phone,
+      email,
+      postalCode: champ(plat, "postalCode"),
+      message,
+      source: "meta",
+      externalId,
+      formName: champ(plat, "formName"),
+      adName: champ(plat, "adName"),
+      campaign: champ(plat, "campaign"),
+      rawJson: JSON.stringify(plat).slice(0, 5000),
+    },
+  });
+
+  // Le prospect entre aussi dans « Tous les clients », sans doublon.
+  const contact = await creerOuCompleterContact({
+    ...(prenom || nom ? { firstName: prenom, lastName: nom } : splitNom(nomComplet)),
+    phone,
+    email,
+    postalCode: lead.postalCode,
+    origine: "meta",
+  });
+  await journaliser(
+    contact.id,
+    "note",
+    [message, lead.adName && `Publicité : ${lead.adName}`, lead.campaign && `Campagne : ${lead.campaign}`]
+      .filter(Boolean)
+      .join("\n") || "Prospect issu d'une publicité.",
+    { sens: "entrant" }
+  );
+  await notifyOwnerNewLead(lead, settings);
+
+  return NextResponse.json({ ok: true, id: lead.id }, { status: 201 });
+}


### PR DESCRIPTION
## Pourquoi la voie directe ne fonctionne pas

Le code de l'intégration Meta est complet (webhook signé, import de rattrapage,
lecture des champs anglais et français). Ce qui bloque est côté Meta : récupérer
les prospects d'une page demande l'autorisation **`leads_retrieval`** en accès
avancé, ce qui suppose une **revue d'application** et une **vérification
d'entreprise**, plus l'acceptation des conditions Lead Ads. Tant que
l'application reste en mode développement, Meta n'envoie les prospects qu'aux
personnes ayant un rôle sur l'application — donc, en pratique, à personne.

## La voie simple

Zapier et Make sont déjà des partenaires validés par Meta : ils reçoivent les
prospects sans revue. On leur ouvre une porte d'entrée.

- **`POST /api/leads/inbound`**, protégée par `Settings.leadsApiKey`
  (paramètre `?key=`, en-tête `X-Api-Key` ou `Authorization: Bearer`), comparée
  en temps constant. Cette clé ne permet que de déposer un prospect.
- **Tolérante sur les noms de champs** : anglais (`full_name`, `phone_number`,
  `post_code`), français (`prénom`, `téléphone`, `code_postal`, `projet`),
  prénom et nom séparés, et le format brut de Meta (`field_data` imbriqué).
- Elle écrit **le prospect, la fiche client, le journal des échanges et l'alerte
  au gérant**, en réutilisant les chemins existants — un lead entré par là est
  indistinguable d'un lead entré par le webhook.
- **Dédoublonnage** sur l'identifiant fourni, ou à défaut sur une empreinte
  téléphone/email/nom + jour : un réessai de Zapier ne crée pas de doublon.
- **Écran d'administration** : une section « La voie simple : Zapier ou Make »
  génère l'adresse complète, l'affiche avec un bouton Copier, donne les cinq
  étapes du Zap et permet de régénérer la clé si elle circule.

### Un piège corrigé au passage

Le format brut de Meta décrit chaque champ par `{ name, values }`. En descendant
dans cet objet, la clé `name` était lue comme un champ à part entière : le
prospect s'appelait littéralement **« full_name »**. On lit désormais le
descripteur sans y descendre.

## Vérifications

- sans clé générée → 503 avec le message qui dit quoi faire ; mauvaise clé → 401 ;
- format Zapier anglais, format français prénom/nom séparés, format Meta brut →
  201 chacun, nom, téléphone, code postal et message correctement extraits ;
- même identifiant renvoyé → 200 `duplicate: true`, aucun doublon créé ;
- ni téléphone ni email → 400 avec un message clair ;
- les 4 prospects apparaissent dans « Prospects reçus », et 4 fiches clients sont
  créées avec `origine: meta` et un échange journalisé.

`npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_