### PR TITLE
Clients : l'adresse dans le formulaire « Nouveau client »

### DIFF
--- a/app/src/app/admin/clients/page.tsx
+++ b/app/src/app/admin/clients/page.tsx
@@ -5,6 +5,7 @@
 // ligne s'ouvre sur la fiche complète (coordonnées, RDV, journal des échanges).
 import { Fragment, useEffect, useState } from "react";
 import FicheContact from "./FicheContact";
+import AddressAutocomplete, { type AddressValue } from "@/components/AddressAutocomplete";
 import { telFr } from "@/lib/rdvLabels";
 
 export type Contact = {
@@ -120,6 +121,7 @@ export default function AdminClientsPage() {
     lastName: "",
     phone: "",
     email: "",
+    address: "",
     postalCode: "",
     city: "",
     note: "",
@@ -173,7 +175,10 @@ export default function AdminClientsPage() {
     });
     if (res.ok) {
       setNouveau(false);
-      setBrouillon({ firstName: "", lastName: "", phone: "", email: "", postalCode: "", city: "", note: "" });
+      setBrouillon({
+        firstName: "", lastName: "", phone: "", email: "",
+        address: "", postalCode: "", city: "", note: "",
+      });
       charger();
     }
   }
@@ -230,8 +235,6 @@ export default function AdminClientsPage() {
                 ["lastName", "Nom"],
                 ["phone", "Téléphone"],
                 ["email", "Email"],
-                ["postalCode", "Code postal"],
-                ["city", "Ville"],
               ] as const
             ).map(([champ, libelle]) => (
               <input
@@ -243,6 +246,18 @@ export default function AdminClientsPage() {
               />
             ))}
           </div>
+          {/* Adresse complète, saisie d'un bloc : le même champ que le tunnel
+              de réservation, qui remplit code postal et ville tout seul. */}
+          <AddressAutocomplete
+            label="Adresse"
+            optional
+            value={{
+              address: brouillon.address,
+              postalCode: brouillon.postalCode,
+              city: brouillon.city,
+            }}
+            onChange={(v: AddressValue) => setBrouillon({ ...brouillon, ...v })}
+          />
           <textarea
             className="input"
             rows={2}


### PR DESCRIPTION
Le formulaire d'ajout d'un client à la main ne demandait que le code postal et la
ville. Un client noté pendant un appel arrivait donc sans adresse, alors que la
colonne **Adresse** du tableau l'attend et que `POST /api/admin/contacts`
l'acceptait déjà — seul le formulaire ne l'envoyait pas.

Les deux champs « Code postal » et « Ville » sont remplacés par le composant
**`AddressAutocomplete`**, celui du tunnel de réservation : l'adresse se saisit
d'un bloc et remplit le code postal et la ville toute seule. Il est passé en
`optional`, donc aucun champ ne devient obligatoire.

## Vérification

Création de « Hélène Roux », 23 bis rue du canal de l'abbé, 34360 Saint-Chinian,
avec une note d'appel :

- la ligne du tableau affiche l'adresse complète ;
- en base : `address`, `postalCode` et `city` renseignés séparément,
  `origine: phone`, la note enregistrée comme échange.

`npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_