### PR TITLE
Leads Meta : alerte si les adresses affichées pointent vers localhost

### DIFF
--- a/app/src/app/admin/meta/page.tsx
+++ b/app/src/app/admin/meta/page.tsx
@@ -203,6 +203,15 @@ export default function AdminMetaPage() {
         <p className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm font-medium text-red-700">{erreur}</p>
       )}
 
+      {s.webhookUrl.includes("localhost") && (
+        <p className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm font-medium text-red-700">
+          Les adresses ci-dessous pointent vers <b>localhost</b> : la variable
+          <b> NEXT_PUBLIC_APP_URL</b> n&apos;est pas renseignée sur Vercel. Mettez-y l&apos;adresse
+          publique du site (par exemple <span className="font-mono">https://arborispaysage.eu</span>)
+          avant de les recopier chez Facebook, sinon la connexion échouera.
+        </p>
+      )}
+
       <div className="space-y-6">
         {/* 1. Application Meta */}
         <section className="card space-y-3">


### PR DESCRIPTION
Les deux adresses que le gérant recopie chez Facebook (URI de redirection et URL
de rappel du webhook) sont construites depuis `NEXT_PUBLIC_APP_URL`. Si la
variable n'est pas renseignée sur Vercel, elles s'affichent en
`http://localhost:3000/…` — recopiées telles quelles chez Facebook, la connexion
échoue sans message clair.

Un bandeau rouge apparaît désormais en tête de l'écran dans ce cas, avec la
variable à renseigner et un exemple de valeur.

`npm run build` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_