### PR TITLE
Connexion Meta : rester sur le domaine d'où vient le clic

### DIFF
--- a/app/src/app/admin/meta/page.tsx
+++ b/app/src/app/admin/meta/page.tsx
@@ -203,15 +203,6 @@ export default function AdminMetaPage() {
         <p className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm font-medium text-red-700">{erreur}</p>
       )}
 
-      {s.webhookUrl.includes("localhost") && (
-        <p className="mb-4 rounded-xl bg-red-50 px-4 py-3 text-sm font-medium text-red-700">
-          Les adresses ci-dessous pointent vers <b>localhost</b> : la variable
-          <b> NEXT_PUBLIC_APP_URL</b> n&apos;est pas renseignée sur Vercel. Mettez-y l&apos;adresse
-          publique du site (par exemple <span className="font-mono">https://arborispaysage.eu</span>)
-          avant de les recopier chez Facebook, sinon la connexion échouera.
-        </p>
-      )}
-
       <div className="space-y-6">
         {/* 1. Application Meta */}
         <section className="card space-y-3">

--- a/app/src/app/api/admin/meta/route.ts
+++ b/app/src/app/api/admin/meta/route.ts
@@ -3,13 +3,17 @@ import crypto from "crypto";
 import { prisma } from "@/lib/prisma";
 import { isAdminAuthenticated } from "@/lib/auth";
 import { getSettings } from "@/lib/settings";
-import { appUrl } from "@/lib/templates";
+import { headers } from "next/headers";
+import { requestBaseUrl } from "@/lib/templates";
 import { metaRedirectUri } from "@/lib/meta";
 
 export const dynamic = "force-dynamic";
 
 /** État de la connexion Meta — aucun jeton n'est renvoyé au navigateur. */
 async function status() {
+  // Les adresses montrées doivent être celles du domaine consulté : c'est
+  // celui-là que Facebook doit autoriser et appeler.
+  const site = requestBaseUrl(headers());
   const s = await getSettings();
   const [leads, aTraiter] = await Promise.all([
     prisma.lead.findMany({ orderBy: { createdAt: "desc" }, take: 100 }),
@@ -26,10 +30,10 @@ async function status() {
     connectedAt: s.metaConnectedAt,
     leadsEnabled: s.metaLeadsEnabled,
     verifyToken: s.metaVerifyToken,
-    webhookUrl: `${appUrl()}/api/meta/webhook`,
+    webhookUrl: `${site}/api/meta/webhook`,
     // Facebook refuse la connexion si cette adresse n'est pas déclarée dans
     // « Facebook Login → Valid OAuth Redirect URIs » : il faut la montrer.
-    redirectUri: metaRedirectUri(appUrl()),
+    redirectUri: metaRedirectUri(site),
     leads,
     aTraiter,
   };

--- a/app/src/app/api/meta/oauth/callback/route.ts
+++ b/app/src/app/api/meta/oauth/callback/route.ts
@@ -4,7 +4,7 @@ import { prisma } from "@/lib/prisma";
 import { isAdminAuthenticated } from "@/lib/auth";
 import { getSettings } from "@/lib/settings";
 import { exchangeCodeForToken, listPages, subscribePageToLeads } from "@/lib/meta";
-import { appUrl } from "@/lib/templates";
+import { requestBaseUrl } from "@/lib/templates";
 
 export const dynamic = "force-dynamic";
 
@@ -12,9 +12,11 @@ export const dynamic = "force-dynamic";
 // Si le compte n'a qu'une seule page, elle est reliée automatiquement ;
 // sinon le gérant choisit dans la liste.
 export async function GET(req: NextRequest) {
-  const base = `${appUrl()}/admin/meta`;
+  // Même domaine qu'au départ : c'est ce qui garde la session et le jeton.
+  const site = requestBaseUrl(req.headers);
+  const base = `${site}/admin/meta`;
   if (!isAdminAuthenticated()) {
-    return NextResponse.redirect(`${appUrl()}/admin/login`);
+    return NextResponse.redirect(`${site}/admin/login`);
   }
   const code = req.nextUrl.searchParams.get("code");
   const state = req.nextUrl.searchParams.get("state");
@@ -25,7 +27,7 @@ export async function GET(req: NextRequest) {
 
   try {
     const settings = await getSettings();
-    const userToken = await exchangeCodeForToken(settings, appUrl(), code);
+    const userToken = await exchangeCodeForToken(settings, site, code);
     const pages = await listPages(userToken);
 
     const data: Record<string, unknown> = { metaUserToken: userToken, metaConnectedAt: new Date() };

--- a/app/src/app/api/meta/oauth/start/route.ts
+++ b/app/src/app/api/meta/oauth/start/route.ts
@@ -1,22 +1,26 @@
 import { NextResponse } from "next/server";
+import { headers } from "next/headers";
 import { isAdminAuthenticated } from "@/lib/auth";
 import { getSettings } from "@/lib/settings";
 import { metaAuthUrl, metaConfigured } from "@/lib/meta";
-import { appUrl } from "@/lib/templates";
+import { requestBaseUrl } from "@/lib/templates";
 
 export const dynamic = "force-dynamic";
 
 // GET /api/meta/oauth/start — envoie le gérant sur la page de connexion Facebook.
 export async function GET() {
+  // Le domaine d'où vient le clic : l'aller-retour OAuth doit y revenir,
+  // sinon la session du gérant est perdue en route.
+  const base = requestBaseUrl(headers());
   if (!isAdminAuthenticated()) {
-    return NextResponse.redirect(`${appUrl()}/admin/login`);
+    return NextResponse.redirect(`${base}/admin/login`);
   }
   const settings = await getSettings();
   if (!metaConfigured(settings)) {
-    return NextResponse.redirect(`${appUrl()}/admin/meta?meta=non_configure`);
+    return NextResponse.redirect(`${base}/admin/meta?meta=non_configure`);
   }
   const state = crypto.randomUUID();
-  const res = NextResponse.redirect(metaAuthUrl(settings, appUrl(), state));
+  const res = NextResponse.redirect(metaAuthUrl(settings, base, state));
   // Protection CSRF : l'état renvoyé par Meta doit correspondre au cookie.
   res.cookies.set("meta_oauth_state", state, {
     httpOnly: true,

--- a/app/src/lib/templates.ts
+++ b/app/src/lib/templates.ts
@@ -5,6 +5,22 @@ export function appUrl(): string {
   return (process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000").replace(/\/$/, "");
 }
 
+/**
+ * Adresse du site telle que le navigateur la voit, déduite de la requête.
+ *
+ * Indispensable pour la connexion Meta : le site répond sur plusieurs domaines
+ * (domaine définitif et adresse Vercel). Si l'aller-retour OAuth change de
+ * domaine en route, le cookie de session et le jeton anti-CSRF restent sur le
+ * premier et la connexion échoue sans raison visible. On reste donc sur le
+ * domaine d'où le gérant a cliqué, quel que soit NEXT_PUBLIC_APP_URL.
+ */
+export function requestBaseUrl(h: Headers): string {
+  const host = h.get("x-forwarded-host") || h.get("host");
+  if (!host) return appUrl();
+  const proto = h.get("x-forwarded-proto") || (host.startsWith("localhost") ? "http" : "https");
+  return `${proto}://${host}`.replace(/\/$/, "");
+}
+
 /** Remplace les variables {{...}} d'un modèle de message.
  *  `groupDates` (chantier multi-jours) : {{date}} devient « du … au … (N jours) ». */
 export function renderTemplate(


### PR DESCRIPTION
## La cause de l'échec

Le site répond sur **deux domaines** : `arborispaysage.eu` et l'adresse Vercel.
L'`redirect_uri` envoyée à Facebook était construite depuis
`NEXT_PUBLIC_APP_URL`, réglée sur le domaine Vercel.

Conséquence, l'aller-retour changeait de domaine en cours de route :

1. le gérant clique depuis `arborispaysage.eu` — cookie de session et jeton
   anti-CSRF y sont déposés ;
2. Facebook le renvoie sur `arboris-paysage.vercel.app` ;
3. là, ni la session ni le jeton n'existent → renvoi vers la page de connexion,
   ou « Connexion expirée, recommencez ».

La connexion ne pouvait donc **jamais** aboutir, sans message explicite. C'est
l'explication des leads Meta qui n'arrivaient pas.

## Le correctif

- **`requestBaseUrl(headers)`** déduit l'adresse du site de `x-forwarded-host` /
  `x-forwarded-proto`, c'est-à-dire du domaine réellement consulté.
- `oauth/start` et `oauth/callback` l'utilisent pour l'`redirect_uri` **et** pour
  toutes leurs redirections : les deux moitiés du parcours partagent enfin un
  seul domaine, donc les mêmes cookies. L'`redirect_uri` de l'échange de jeton
  est identique à celle de l'autorisation, comme Facebook l'exige.
- L'écran d'administration affiche l'URI de redirection et l'URL de rappel **du
  domaine consulté** — celles-là mêmes qu'il faut déclarer chez Facebook.
- Bandeau « localhost » retiré, devenu sans objet.

`NEXT_PUBLIC_APP_URL` reste utilisée ailleurs (liens des emails, .ics) ; la
corriger sur Vercel reste souhaitable, mais la connexion Meta n'en dépend plus.

## Vérifications

Avec `NEXT_PUBLIC_APP_URL` volontairement réglée sur un mauvais domaine :

- consulté depuis `arborispaysage.eu` → les deux adresses affichées sont en
  `arborispaysage.eu` ;
- consulté depuis l'adresse Vercel → elles suivent ce domaine ;
- `redirect_uri` réellement envoyée à Facebook :
  `https://arborispaysage.eu/api/meta/oauth/callback`, avec les quatre
  autorisations attendues.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_