### PR TITLE
Meta : autorisation pages_manage_ads et connexion préservée

### DIFF
--- a/app/src/app/admin/meta/page.tsx
+++ b/app/src/app/admin/meta/page.tsx
@@ -38,6 +38,8 @@ type Status = {
 
 const MESSAGES: Record<string, string> = {
   ok: "Compte Meta connecté et page reliée : les prospects arriveront ici automatiquement.",
+  sans_temps_reel:
+    "Page reliée. L'arrivée automatique n'a pas pu être activée : utilisez « Importer les prospects existants », et reconnectez le compte pour réessayer.",
   choisir_page: "Compte connecté. Choisissez la page Facebook qui diffuse vos publicités.",
   aucune_page: "Compte connecté, mais aucune page Facebook n'y est rattachée.",
   refuse: "Connexion annulée.",

--- a/app/src/app/api/admin/meta/pages/route.ts
+++ b/app/src/app/api/admin/meta/pages/route.ts
@@ -42,12 +42,28 @@ export async function POST(req: NextRequest) {
     const pages = await listPages(settings.metaUserToken);
     const page = pages.find((p) => p.id === body.pageId);
     if (!page) return NextResponse.json({ error: "Page introuvable" }, { status: 404 });
-    await subscribePageToLeads(page);
+    // La page est reliée quoi qu'il arrive : sans l'abonnement temps réel,
+    // l'import des prospects fonctionne toujours.
+    let abonnee = true;
+    let avertissement = "";
+    try {
+      await subscribePageToLeads(page);
+    } catch (e) {
+      abonnee = false;
+      avertissement = (e as Error).message;
+      console.error("Abonnement leadgen refusé:", e);
+    }
     await prisma.settings.update({
       where: { id: "main" },
       data: { metaPageId: page.id, metaPageName: page.name, metaPageToken: page.access_token },
     });
-    return NextResponse.json({ ok: true, pageId: page.id, pageName: page.name });
+    return NextResponse.json({
+      ok: true,
+      pageId: page.id,
+      pageName: page.name,
+      abonnee,
+      avertissement,
+    });
   } catch (e) {
     return NextResponse.json({ error: (e as Error).message }, { status: 502 });
   }

--- a/app/src/app/api/meta/oauth/callback/route.ts
+++ b/app/src/app/api/meta/oauth/callback/route.ts
@@ -31,17 +31,32 @@ export async function GET(req: NextRequest) {
     const pages = await listPages(userToken);
 
     const data: Record<string, unknown> = { metaUserToken: userToken, metaConnectedAt: new Date() };
+    // L'abonnement temps réel peut échouer (autorisation manquante) sans que la
+    // page soit inutilisable : reliée, elle permet déjà l'import des prospects.
+    // On garde donc la connexion et on signale seulement le temps réel.
+    let abonnee = true;
     if (pages.length === 1) {
-      await subscribePageToLeads(pages[0]);
+      try {
+        await subscribePageToLeads(pages[0]);
+      } catch (e) {
+        abonnee = false;
+        console.error("Abonnement leadgen refusé:", e);
+      }
       data.metaPageId = pages[0].id;
       data.metaPageName = pages[0].name;
       data.metaPageToken = pages[0].access_token;
     }
     await prisma.settings.update({ where: { id: "main" }, data });
 
-    const res = NextResponse.redirect(
-      `${base}?meta=${pages.length === 1 ? "ok" : pages.length ? "choisir_page" : "aucune_page"}`
-    );
+    const etat =
+      pages.length === 1
+        ? abonnee
+          ? "ok"
+          : "sans_temps_reel"
+        : pages.length
+          ? "choisir_page"
+          : "aucune_page";
+    const res = NextResponse.redirect(`${base}?meta=${etat}`);
     res.cookies.delete("meta_oauth_state");
     return res;
   } catch (e) {

--- a/app/src/lib/meta.ts
+++ b/app/src/lib/meta.ts
@@ -16,6 +16,9 @@ const GRAPH = "https://graph.facebook.com/v21.0";
 export const META_SCOPES = [
   "pages_show_list",
   "pages_manage_metadata",
+  // Facebook exige aussi celle-ci pour abonner une Page à l'événement leadgen
+  // (« (#200) Requires pages_manage_ads permission to manage the object »).
+  "pages_manage_ads",
   "leads_retrieval",
   "business_management",
 ].join(",");


### PR DESCRIPTION
Constaté en conditions réelles : le compte se connecte, puis l'écran affiche
`(#200) Requires pages_manage_ads permission to manage the object`.

## Deux corrections

**1. L'autorisation manquante.** Abonner une Page à l'événement `leadgen`
réclame `pages_manage_ads`, que nous ne demandions pas. Elle est ajoutée aux
autorisations demandées à la connexion (les cinq sont déjà accordées côté
application Meta du client).

**2. Une connexion valable ne doit plus être jetée.** `subscribePageToLeads()`
levait une exception **avant** l'enregistrement du jeton de page : un échec de
l'abonnement temps réel faisait donc perdre toute la connexion, alors que
l'import des prospects n'en dépend pas.

Désormais, dans le retour OAuth comme dans le choix manuel de la page, la page
est enregistrée quoi qu'il arrive et seul le temps réel est signalé —
nouveau message : « Page reliée. L'arrivée automatique n'a pas pu être activée :
utilisez « Importer les prospects existants », et reconnectez le compte pour
réessayer. »

## Vérification

Autorisations effectivement demandées à Facebook :

```
pages_show_list
pages_manage_metadata
pages_manage_ads
leads_retrieval
business_management
```

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_