### PR TITLE
Leads à traiter : afficher les leads du jour et pouvoir les cocher

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -134,6 +134,9 @@ model Contact {
   city         String   @default("")
   // web | manual | meta | phone | recommandation
   origine      String   @default("web")
+  // Marqué « déjà contacté » depuis le tableau de bord : le lead sort de la
+  // liste des choses à faire sans qu'il faille lui inventer un rendez-vous.
+  contacteAt   DateTime?
   agenceId     String?
   agence       Agence?  @relation(fields: [agenceId], references: [id], onDelete: SetNull)
   notes        String   @default("")

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -214,6 +214,8 @@ export default function AdminDashboard() {
   const [tuiles, setTuiles] = useState<Tuiles | null>(null);
   const [mois, setMois] = useState<Mois[]>([]);
   const [aTraiter, setATraiter] = useState<ATraiter[]>([]);
+  const [aTraiterTotal, setATraiterTotal] = useState(0);
+  const [enCours, setEnCours] = useState("");
   const [prochains, setProchains] = useState<Prochain[]>([]);
 
   useEffect(() => {
@@ -229,10 +231,26 @@ export default function AdminDashboard() {
         setTuiles(d.tuiles ?? null);
         setMois(d.mois ?? []);
         setATraiter(d.aTraiter ?? []);
+        setATraiterTotal(d.aTraiterTotal ?? (d.aTraiter ?? []).length);
         setProchains(d.prochains ?? []);
       })
       .catch(() => {});
   }, []);
+
+  /** « Déjà contacté » : le lead quitte la liste, sa fiche est inchangée. */
+  async function marquerContacte(c: ATraiter) {
+    setEnCours(c.id);
+    const res = await fetch(`/api/admin/contacts/${c.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contacte: true }),
+    });
+    setEnCours("");
+    if (res.ok) {
+      setATraiter((l) => l.filter((x) => x.id !== c.id));
+      setATraiterTotal((n) => Math.max(0, n - 1));
+    }
+  }
 
   if (!tuiles) {
     return <main className="mx-auto max-w-6xl px-4 py-10 text-center text-leaf-800/60">Chargement…</main>;
@@ -293,9 +311,9 @@ export default function AdminDashboard() {
           <div className="flex items-center justify-between gap-2">
             <h2 className="flex items-center gap-2 font-bold">
               Leads à traiter
-              {aTraiter.length > 0 && (
+              {aTraiterTotal > 0 && (
                 <span className="rounded-full bg-red-100 px-2 py-0.5 text-xs font-bold text-red-700">
-                  {aTraiter.length}
+                  {aTraiterTotal}
                 </span>
               )}
             </h2>
@@ -303,7 +321,9 @@ export default function AdminDashboard() {
               Voir tout
             </Link>
           </div>
-          <p className="text-sm text-leaf-800/60">Entrants depuis plus de 24 h</p>
+          <p className="text-sm text-leaf-800/60">
+            Sans rendez-vous ni devis — marquez « contacté » quand c'est fait
+          </p>
 
           {aTraiter.length === 0 ? (
             <p className="py-8 text-center text-sm text-leaf-800/50">
@@ -318,13 +338,13 @@ export default function AdminDashboard() {
                 };
                 const nom = `${c.firstName} ${c.lastName}`.trim() || "Sans nom";
                 return (
-                  <li key={c.id}>
+                  <li key={c.id} className="group relative">
                     {/* La recherche par téléphone retrouve la fiche même très
                         ancienne : la liste des clients ne charge que les
                         derniers, un lien par identifiant tomberait à vide. */}
                     <Link
                       href={`/admin/clients?q=${encodeURIComponent(c.phone || nom)}`}
-                      className="flex items-center gap-3 rounded-xl px-2 py-2.5 transition hover:bg-leaf-50"
+                      className="flex items-center gap-3 rounded-xl px-2 py-2.5 pr-9 transition hover:bg-leaf-50"
                     >
                       <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-leaf-100 bg-white text-xs font-bold text-leaf-800/70">
                         {initiales(c.firstName, c.lastName)}
@@ -343,16 +363,34 @@ export default function AdminDashboard() {
                       <span className="shrink-0 text-right">
                         <span
                           className={`block text-xs font-bold ${
-                            c.jours >= 7 ? "text-red-600" : "text-amber-600"
+                            c.jours >= 7
+                              ? "text-red-600"
+                              : c.jours === 0
+                                ? "text-leaf-700"
+                                : "text-amber-600"
                           }`}
                         >
-                          {c.jours} jour{c.jours > 1 ? "s" : ""}
+                          {c.jours === 0
+                            ? "aujourd'hui"
+                            : `${c.jours} jour${c.jours > 1 ? "s" : ""}`}
                         </span>
                         <span className="block text-[11px] tabular-nums text-leaf-800/50">
                           {dateHeure(c.createdAt)}
                         </span>
                       </span>
                     </Link>
+                    {/* Hors du lien : un clic ici ne doit pas ouvrir la fiche. */}
+                    <button
+                      onClick={() => marquerContacte(c)}
+                      disabled={enCours === c.id}
+                      title={`Marquer ${nom} comme déjà contacté`}
+                      aria-label={`Marquer ${nom} comme déjà contacté`}
+                      className="absolute right-1 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-leaf-800/30 transition hover:bg-white hover:text-leaf-700 disabled:opacity-40"
+                    >
+                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="h-4 w-4">
+                        <path d="m4 12 5 5L20 6" />
+                      </svg>
+                    </button>
                   </li>
                 );
               })}

--- a/app/src/app/api/admin/contacts/[id]/route.ts
+++ b/app/src/app/api/admin/contacts/[id]/route.ts
@@ -57,6 +57,10 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     data.phone = body.phone.trim();
     data.phoneKey = phoneKeyOf(body.phone);
   }
+  // « Déjà contacté » depuis le tableau de bord : sort le lead de la liste.
+  if (body.contacte !== undefined) {
+    data.contacteAt = body.contacte ? new Date() : null;
+  }
   if (body.agenceId !== undefined) {
     const brut = String(body.agenceId ?? "").trim();
     data.agenceId = brut && (await prisma.agence.findUnique({ where: { id: brut } })) ? brut : null;

--- a/app/src/app/api/admin/dashboard/route.ts
+++ b/app/src/app/api/admin/dashboard/route.ts
@@ -47,16 +47,21 @@ export async function GET() {
       }),
       prisma.document.findMany({ select: { type: true, date: true, status: true, itemsJson: true } }),
       // Demandes que personne n'a encore prises en main : ni affaire, ni
-      // rendez-vous, arrivées il y a plus de 24 h. C'est la liste qui garantit
+      // rendez-vous, ni marquées « déjà contacté ». C'est la liste qui garantit
       // qu'aucun prospect ne se perd.
+      //
+      // Le filtre « arrivé il y a plus de 24 h » a été retiré : à l'import des
+      // prospects Meta, 101 fiches créées le jour même restaient invisibles ici
+      // — exactement celles qu'il fallait rappeler. C'est le gérant qui décide
+      // quand un lead sort de la liste, pas l'horloge.
       prisma.contact.findMany({
         where: {
-          createdAt: { lt: new Date(Date.now() - 24 * 3600_000) },
+          contacteAt: null,
           affaires: { none: {} },
           bookings: { none: {} },
         },
         orderBy: { createdAt: "asc" },
-        take: 8,
+        take: 12,
         select: {
           id: true,
           firstName: true,
@@ -110,6 +115,10 @@ export async function GET() {
       ? Math.round(((nouveauxCeMois - nouveauxMoisPrec) / nouveauxMoisPrec) * 100)
       : null;
 
+  const aTraiterTotal = await prisma.contact.count({
+    where: { contacteAt: null, affaires: { none: {} }, bookings: { none: {} } },
+  });
+
   const aTraiter = aTraiterBruts.map(({ interactions, notes, ...c }) => ({
     ...c,
     // Une seule ligne : le journal complet est sur la fiche du client.
@@ -131,6 +140,7 @@ export async function GET() {
     },
     mois,
     aTraiter,
+    aTraiterTotal,
     prochains: prochains.map((b) => ({
       ...b,
       jour: b.startAt ? utcToParis(b.startAt).date : "",


### PR DESCRIPTION
L'import des prospects Meta a créé **101 fiches datées d'aujourd'hui**, et le
panneau ne listait que les contacts vieux de plus de 24 h : « Rien en attente »
alors que 101 personnes attendaient un rappel. Le filtre cachait exactement ce
qu'il fallait montrer.

## Ce qui change

- **Le filtre d'âge est retiré.** Un lead quitte la liste quand le gérant le
  décide, pas quand l'horloge le décide. Le critère devient : aucun rendez-vous,
  aucune affaire, pas marqué contacté.
- **Bouton « déjà contacté »** (une coche) sur chaque ligne : le lead sort de la
  liste, **sa fiche client reste intacte** — c'est une liste de choses à faire,
  pas une corbeille. Champ `Contact.contacteAt`, posé via
  `PATCH /api/admin/contacts/:id { contacte }`.
- La coche est **hors du lien** vers la fiche : un clic dessus ne navigue pas.
- **La pastille compte tous les leads en attente**, pas seulement les douze
  affichés — avec 101 leads, « 12 » aurait été trompeur.
- « 0 jour » devient **« aujourd'hui »**, en vert plutôt qu'en orange.

## Vérifications

Cinq leads créés il y a 5 à 45 minutes :

- les 5 s'affichent (aucun n'apparaissait avant ce correctif) ;
- clic sur la coche → la ligne disparaît, la pastille passe de 5 à 4 ;
- après rechargement : toujours 4, l'état est bien enregistré ;
- `GET /api/admin/contacts` renvoie toujours **5 fiches** : rien n'a été supprimé.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_