### PR TITLE
Leads à traiter : boutons « Déjà contacté » et « À recontacter »

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -134,9 +134,11 @@ model Contact {
   city         String   @default("")
   // web | manual | meta | phone | recommandation
   origine      String   @default("web")
-  // Marqué « déjà contacté » depuis le tableau de bord : le lead sort de la
-  // liste des choses à faire sans qu'il faille lui inventer un rendez-vous.
+  // Suivi des leads depuis le tableau de bord, sans avoir à leur inventer un
+  // rendez-vous : « déjà contacté » sort de la liste des choses à faire,
+  // « à recontacter » y reste mais porte la date du dernier essai.
   contacteAt   DateTime?
+  relanceAt    DateTime?
   agenceId     String?
   agence       Agence?  @relation(fields: [agenceId], references: [id], onDelete: SetNull)
   notes        String   @default("")

--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -25,6 +25,8 @@ type ATraiter = {
   createdAt: string;
   /** Ce que le prospect demande, en une ligne. */
   demande: string;
+  /** Date du dernier essai d'appel, si marqué « à recontacter ». */
+  relanceAt: string | null;
   jours: number;
 };
 type Prochain = {
@@ -237,18 +239,26 @@ export default function AdminDashboard() {
       .catch(() => {});
   }, []);
 
-  /** « Déjà contacté » : le lead quitte la liste, sa fiche est inchangée. */
-  async function marquerContacte(c: ATraiter) {
+  /**
+   * Suivi d'un lead. « Déjà contacté » le sort de la liste ; « à recontacter »
+   * l'y laisse — c'est encore à faire — mais garde la date du dernier essai.
+   * Dans les deux cas la fiche client est intacte : rien n'est supprimé.
+   */
+  async function suivre(c: ATraiter, geste: "contacte" | "relance") {
     setEnCours(c.id);
     const res = await fetch(`/api/admin/contacts/${c.id}`, {
       method: "PATCH",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ contacte: true }),
+      body: JSON.stringify(geste === "contacte" ? { contacte: true } : { relance: true }),
     });
     setEnCours("");
-    if (res.ok) {
+    if (!res.ok) return;
+    if (geste === "contacte") {
       setATraiter((l) => l.filter((x) => x.id !== c.id));
       setATraiterTotal((n) => Math.max(0, n - 1));
+    } else {
+      const quand = new Date().toISOString();
+      setATraiter((l) => l.map((x) => (x.id === c.id ? { ...x, relanceAt: quand } : x)));
     }
   }
 
@@ -338,13 +348,13 @@ export default function AdminDashboard() {
                 };
                 const nom = `${c.firstName} ${c.lastName}`.trim() || "Sans nom";
                 return (
-                  <li key={c.id} className="group relative">
+                  <li key={c.id} className="border-b border-leaf-50 last:border-0">
                     {/* La recherche par téléphone retrouve la fiche même très
                         ancienne : la liste des clients ne charge que les
                         derniers, un lien par identifiant tomberait à vide. */}
                     <Link
                       href={`/admin/clients?q=${encodeURIComponent(c.phone || nom)}`}
-                      className="flex items-center gap-3 rounded-xl px-2 py-2.5 pr-9 transition hover:bg-leaf-50"
+                      className="flex items-center gap-3 rounded-xl px-2 pb-1 pt-2.5 transition hover:bg-leaf-50"
                     >
                       <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full border border-leaf-100 bg-white text-xs font-bold text-leaf-800/70">
                         {initiales(c.firstName, c.lastName)}
@@ -380,17 +390,38 @@ export default function AdminDashboard() {
                       </span>
                     </Link>
                     {/* Hors du lien : un clic ici ne doit pas ouvrir la fiche. */}
-                    <button
-                      onClick={() => marquerContacte(c)}
-                      disabled={enCours === c.id}
-                      title={`Marquer ${nom} comme déjà contacté`}
-                      aria-label={`Marquer ${nom} comme déjà contacté`}
-                      className="absolute right-1 top-1/2 flex h-7 w-7 -translate-y-1/2 items-center justify-center rounded-full text-leaf-800/30 transition hover:bg-white hover:text-leaf-700 disabled:opacity-40"
-                    >
-                      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="h-4 w-4">
-                        <path d="m4 12 5 5L20 6" />
-                      </svg>
-                    </button>
+                    <div className="flex flex-wrap items-center gap-1.5 px-2 pb-2.5 pl-[3.25rem]">
+                      <button
+                        onClick={() => suivre(c, "contacte")}
+                        disabled={enCours === c.id}
+                        className="flex items-center gap-1 rounded-lg border border-leaf-200 px-2 py-1 text-[11px] font-semibold text-leaf-800 transition hover:border-leaf-600 hover:bg-leaf-50 disabled:opacity-40"
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="h-3.5 w-3.5">
+                          <path d="m4 12 5 5L20 6" />
+                        </svg>
+                        Déjà contacté
+                      </button>
+                      <button
+                        onClick={() => suivre(c, "relance")}
+                        disabled={enCours === c.id}
+                        className={`flex items-center gap-1 rounded-lg border px-2 py-1 text-[11px] font-semibold transition disabled:opacity-40 ${
+                          c.relanceAt
+                            ? "border-amber-300 bg-amber-50 text-amber-800"
+                            : "border-leaf-200 text-leaf-800 hover:border-amber-400 hover:bg-amber-50"
+                        }`}
+                      >
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" className="h-3.5 w-3.5">
+                          <path d="M3 12a9 9 0 1 0 3-6.7L3 8" />
+                          <path d="M3 3v5h5" />
+                        </svg>
+                        À recontacter
+                      </button>
+                      {c.relanceAt && (
+                        <span className="text-[11px] text-amber-700">
+                          essai du {dateHeure(c.relanceAt)}
+                        </span>
+                      )}
+                    </div>
                   </li>
                 );
               })}

--- a/app/src/app/api/admin/contacts/[id]/route.ts
+++ b/app/src/app/api/admin/contacts/[id]/route.ts
@@ -57,9 +57,19 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     data.phone = body.phone.trim();
     data.phoneKey = phoneKeyOf(body.phone);
   }
-  // « Déjà contacté » depuis le tableau de bord : sort le lead de la liste.
+  // Suivi rapide depuis le tableau de bord. Chaque geste laisse une trace dans
+  // le journal du contact : sa fiche doit raconter ce qui s'est passé.
+  let journal = "";
   if (body.contacte !== undefined) {
     data.contacteAt = body.contacte ? new Date() : null;
+    if (body.contacte) {
+      data.relanceAt = null;
+      journal = "Marqué « déjà contacté » depuis le tableau de bord.";
+    }
+  }
+  if (body.relance !== undefined) {
+    data.relanceAt = body.relance ? new Date() : null;
+    if (body.relance) journal = "Marqué « à recontacter » depuis le tableau de bord.";
   }
   if (body.agenceId !== undefined) {
     const brut = String(body.agenceId ?? "").trim();
@@ -67,6 +77,9 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   }
 
   const contact = await prisma.contact.update({ where: { id: params.id }, data });
+  if (journal) {
+    await journaliser(contact.id, "appel", journal, { sens: "sortant", auteur: "gerant" });
+  }
   return NextResponse.json({ ok: true, contact });
 }
 

--- a/app/src/app/api/admin/dashboard/route.ts
+++ b/app/src/app/api/admin/dashboard/route.ts
@@ -71,6 +71,7 @@ export async function GET() {
           city: true,
           createdAt: true,
           notes: true,
+          relanceAt: true,
           // Le premier message reçu dit ce que le prospect demande : c'est
           // cette phrase que le gérant lit pour décider quoi faire.
           interactions: {


### PR DESCRIPTION
La coche discrète ajoutée précédemment passait inaperçue et ne couvrait qu'une
seule issue. Chaque ligne porte désormais **deux boutons libellés**.

## Les deux gestes

| Bouton | Effet |
|---|---|
| **✓ Déjà contacté** | Le lead sort de la liste. Efface aussi un éventuel « à recontacter ». |
| **↻ À recontacter** | Le lead **reste** dans la liste — c'est encore à faire — mais s'affiche en ambre avec la **date du dernier essai**. |

`Contact.relanceAt` porte cette date. Les deux gestes écrivent une ligne dans le
**journal du contact** : sa fiche raconte ce qui s'est passé, au lieu de garder
un état muet.

Les boutons sont **hors du lien** vers la fiche client et sur leur propre ligne :
un clic ne fait jamais quitter le tableau de bord par accident.

## Vérifications

Cinq leads récents :

- 2 boutons par ligne ;
- « À recontacter » sur le premier → **toujours 5 leads**, avec « essai du
  20/08 10:41 » affiché ;
- « Déjà contacté » sur le deuxième → 4 leads, pastille à 4 ;
- après rechargement : 4 leads et l'état « à recontacter » toujours là ;
- `GET /api/admin/contacts` renvoie toujours **5 fiches** — rien n'est supprimé.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_