### PR TITLE
Clients : une colonne de statut à la place des quatre anciennes

### DIFF
--- a/app/src/app/admin/clients/page.tsx
+++ b/app/src/app/admin/clients/page.tsx
@@ -7,6 +7,7 @@ import { Fragment, useEffect, useState } from "react";
 import FicheContact from "./FicheContact";
 import AddressAutocomplete, { type AddressValue } from "@/components/AddressAutocomplete";
 import { telFr } from "@/lib/rdvLabels";
+import { ETAPE_PAR_ID, SUIVI_SIMPLE } from "@/lib/pipeline";
 
 export type Contact = {
   id: string;
@@ -28,6 +29,8 @@ export type Contact = {
   contrat: "annuel" | "ponctuel";
   affairesCount: number;
   perdu: boolean;
+  affaireId: string | null;
+  affaireStatut: string;
   dernierEchange: string | null;
 };
 
@@ -37,15 +40,6 @@ type AgenceLite = { id: string; nom: string; couleur: string };
 function euros(n: number): string {
   return n.toLocaleString("fr-FR", { style: "currency", currency: "EUR", maximumFractionDigits: 0 });
 }
-function dateCourte(iso: string | null): string {
-  if (!iso) return "—";
-  return new Date(iso).toLocaleDateString("fr-FR", {
-    day: "2-digit",
-    month: "2-digit",
-    year: "numeric",
-  });
-}
-
 /** Tuile de synthèse : le chiffre d'abord, l'explication ensuite. */
 function Tuile({
   label,
@@ -116,6 +110,7 @@ export default function AdminClientsPage() {
   const [agence, setAgence] = useState("");
   const [ouvert, setOuvert] = useState<string | null>(null);
   const [nouveau, setNouveau] = useState(false);
+  const [majStatut, setMajStatut] = useState("");
   const [brouillon, setBrouillon] = useState({
     firstName: "",
     lastName: "",
@@ -166,6 +161,25 @@ export default function AdminClientsPage() {
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [q, agence]);
+
+  /**
+   * Suivi commercial depuis la liste. La vérité vit dans l'affaire du client :
+   * on met à jour l'affichage tout de suite, puis on recharge pour récupérer
+   * l'identifiant de l'affaire créée le cas échéant.
+   */
+  async function changerSuivi(c: Contact, statut: string) {
+    if (!statut) return;
+    setMajStatut(c.id);
+    setContacts((l) => l.map((x) => (x.id === c.id ? { ...x, affaireStatut: statut } : x)));
+    const res = await fetch(`/api/admin/contacts/${c.id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ statut }),
+    });
+    setMajStatut("");
+    if (res.ok) charger();
+    else setContacts((l) => l.map((x) => (x.id === c.id ? { ...x, affaireStatut: c.affaireStatut } : x)));
+  }
 
   async function creer() {
     const res = await fetch("/api/admin/contacts", {
@@ -307,10 +321,7 @@ export default function AdminClientsPage() {
                 <th className="whitespace-nowrap px-3 py-3 font-semibold">Nom</th>
                 <th className="px-3 py-3 font-semibold">Téléphone</th>
                 <th className="px-3 py-3 font-semibold">Email</th>
-                <th className="px-3 py-3 font-semibold">Adresse</th>
-                <th className="whitespace-nowrap px-3 py-3 font-semibold">Contrat</th>
-                <th className="whitespace-nowrap px-3 py-3 text-right font-semibold">CA généré</th>
-                <th className="whitespace-nowrap px-3 py-3 font-semibold">Dernier échange</th>
+                <th className="px-3 py-3 font-semibold">Où en est-on ?</th>
               </tr>
             </thead>
             <tbody>
@@ -348,30 +359,37 @@ export default function AdminClientsPage() {
                       <td className="max-w-[13rem] truncate px-3 py-3 text-leaf-800/80" title={c.email}>
                         {c.email || "—"}
                       </td>
-                      <td className="max-w-[15rem] truncate px-3 py-3 text-leaf-800/70" title={lieu}>
-                        {lieu || "—"}
-                      </td>
-                      <td className="px-3 py-3">
-                        <span
-                          className={`whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-semibold ${
-                            c.contrat === "annuel"
-                              ? "bg-leaf-100 text-leaf-800"
-                              : "bg-sand-50 text-leaf-800/60"
+                      {/* Le clic sur la ligne ouvre la fiche : il ne doit pas
+                          traverser le sélecteur. */}
+                      <td className="px-3 py-2" onClick={(e) => e.stopPropagation()}>
+                        <select
+                          value={c.affaireStatut}
+                          disabled={majStatut === c.id}
+                          onChange={(e) => changerSuivi(c, e.target.value)}
+                          className={`w-full max-w-[13rem] cursor-pointer rounded-lg border-0 px-2 py-1.5 text-[12px] font-semibold outline-none ring-1 ring-inset ring-leaf-200 focus:ring-leaf-600 disabled:opacity-50 ${
+                            SUIVI_SIMPLE.find((o) => o.id === c.affaireStatut)?.couleur ??
+                            "bg-white text-leaf-800/60"
                           }`}
                         >
-                          {c.contrat === "annuel" ? "Contrat annuel" : "Ponctuel"}
-                        </span>
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-3 text-right font-semibold tabular-nums text-leaf-700">
-                        {c.caGenere > 0 ? euros(c.caGenere) : "—"}
-                      </td>
-                      <td className="whitespace-nowrap px-3 py-3 tabular-nums text-leaf-800/70">
-                        {dateCourte(c.dernierEchange)}
+                          <option value="">— à qualifier —</option>
+                          {SUIVI_SIMPLE.map((o) => (
+                            <option key={o.id} value={o.id}>
+                              {o.label}
+                            </option>
+                          ))}
+                          {/* Étape posée depuis la page Affaires et absente des
+                              cinq choix : on l'affiche plutôt que de la perdre. */}
+                          {c.affaireStatut && !SUIVI_SIMPLE.some((o) => o.id === c.affaireStatut) && (
+                            <option value={c.affaireStatut}>
+                              {ETAPE_PAR_ID[c.affaireStatut]?.label ?? c.affaireStatut}
+                            </option>
+                          )}
+                        </select>
                       </td>
                     </tr>
                     {estOuvert && (
                       <tr>
-                        <td colSpan={8} className="p-0">
+                        <td colSpan={5} className="p-0">
                           <FicheContact id={c.id} agences={agences} onChange={charger} />
                         </td>
                       </tr>

--- a/app/src/app/api/admin/contacts/[id]/route.ts
+++ b/app/src/app/api/admin/contacts/[id]/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { isAdminAuthenticated } from "@/lib/auth";
 import { journaliser, phoneKeyOf } from "@/lib/contacts";
+import { affaireOuverteDe, changerStatut, creerAffaire } from "@/lib/affaires";
+import { ETAPE_PAR_ID } from "@/lib/pipeline";
 
 export const dynamic = "force-dynamic";
 
@@ -74,6 +76,29 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
   if (body.agenceId !== undefined) {
     const brut = String(body.agenceId ?? "").trim();
     data.agenceId = brut && (await prisma.agence.findUnique({ where: { id: brut } })) ? brut : null;
+  }
+
+  // Suivi commercial posé depuis la liste des clients. La vérité reste dans
+  // l'affaire : un contact sans affaire en obtient une, plutôt qu'un second
+  // état parallèle qui finirait par contredire la page Affaires.
+  if (typeof body.statut === "string" && ETAPE_PAR_ID[body.statut]) {
+    const existante =
+      (await affaireOuverteDe(params.id, "chantier")) ??
+      (await prisma.affaire.findFirst({
+        where: { contactId: params.id },
+        orderBy: { updatedAt: "desc" },
+      }));
+    if (existante) {
+      await changerStatut(existante.id, body.statut);
+    } else {
+      await creerAffaire({
+        contactId: params.id,
+        address: existe.address,
+        postalCode: existe.postalCode,
+        city: existe.city,
+        statut: body.statut,
+      });
+    }
   }
 
   const contact = await prisma.contact.update({ where: { id: params.id }, data });

--- a/app/src/app/api/admin/contacts/route.ts
+++ b/app/src/app/api/admin/contacts/route.ts
@@ -57,7 +57,7 @@ export async function GET(req: NextRequest) {
     ids.length
       ? prisma.affaire.findMany({
           where: { contactId: { in: ids } },
-          select: { contactId: true, statut: true, montant: true, projectType: true },
+          select: { id: true, contactId: true, statut: true, montant: true, projectType: true, updatedAt: true },
         })
       : [],
     ids.length
@@ -102,6 +102,19 @@ export async function GET(req: NextRequest) {
   for (const b of rdv) {
     if (b.contactId && b.projectType === "contrat_annuel") de(b.contactId).contrat = true;
   }
+  // L'affaire à montrer dans la liste : la plus récemment bougée. Un contact
+  // peut en porter plusieurs, mais la colonne n'a la place que d'une seule —
+  // la page Affaires reste l'endroit pour les voir toutes.
+  const courante = new Map<string, { id: string; statut: string; quand: number }>();
+  for (const a of affaires) {
+    if (!a.contactId) continue;
+    const quand = a.updatedAt.getTime();
+    const actuelle = courante.get(a.contactId);
+    if (!actuelle || quand > actuelle.quand) {
+      courante.set(a.contactId, { id: a.id, statut: a.statut, quand });
+    }
+  }
+
   const dernierEchange = new Map<string, string>();
   for (const d of derniers) {
     if (d._max.createdAt) dernierEchange.set(d.contactId, d._max.createdAt.toISOString());
@@ -134,6 +147,8 @@ export async function GET(req: NextRequest) {
         contrat: r?.contrat ? "annuel" : "ponctuel",
         affairesCount: r?.affaires ?? 0,
         perdu: r?.perdu ?? false,
+        affaireId: courante.get(c.id)?.id ?? null,
+        affaireStatut: courante.get(c.id)?.statut ?? "",
         dernierEchange: dernierEchange.get(c.id) ?? null,
       };
     }),

--- a/app/src/lib/pipeline.ts
+++ b/app/src/lib/pipeline.ts
@@ -48,6 +48,20 @@ export const ETAPES: Etape[] = [
     aide: "Annulation — neutre dans les statistiques" },
 ];
 
+/**
+ * Vocabulaire simplifié du gérant, pour le suivi rapide depuis la liste des
+ * clients : cinq états qui couvrent son quotidien, dits avec ses mots. Ce sont
+ * les mêmes étapes que le pipeline — un seul `statut` reste la source de
+ * vérité, la page Affaires en montre simplement le détail complet.
+ */
+export const SUIVI_SIMPLE: { id: string; label: string; couleur: string }[] = [
+  { id: "devis_a_faire", label: "En attente de devis", couleur: "bg-sand-50 text-leaf-800/80" },
+  { id: "devis_envoye", label: "Devis envoyé", couleur: "bg-amber-100 text-amber-800" },
+  { id: "gagne", label: "Chantier à programmer", couleur: "bg-blue-100 text-blue-800" },
+  { id: "chantier_en_cours", label: "Chantier en cours", couleur: "bg-leaf-100 text-leaf-800" },
+  { id: "termine", label: "Chantier terminé", couleur: "bg-leaf-600/15 text-leaf-800" },
+];
+
 export const ETAPE_PAR_ID: Record<string, Etape> = Object.fromEntries(
   ETAPES.map((e) => [e.id, e])
 );


### PR DESCRIPTION
Les colonnes **Adresse**, **Contrat**, **CA généré** et **Dernier échange** sont
retirées du tableau des clients, remplacées par une colonne **« Où en est-on ? »**
avec un sélecteur modifiable :

- En attente de devis
- Devis envoyé
- Chantier à programmer
- Chantier en cours
- Chantier terminé

## Un seul état, pas deux

Le sélecteur écrit dans le **`statut` de l'affaire du client**, pas dans un
nouveau champ. Un état parallèle aurait fini par contredire la page Affaires et
le taux de transformation des statistiques.

- `SUIVI_SIMPLE` (dans `lib/pipeline.ts`) associe les cinq libellés du gérant à
  des étapes existantes du pipeline — les deux écrans décrivent la même chose.
- Choisir un statut pour un client **sans affaire en crée une**, rattachée au
  secteur déduit de son code postal.
- Une étape posée depuis la page Affaires et absente des cinq choix (« En
  relance », « Perdu »…) reste **affichée** au lieu d'être perdue silencieusement.
- Chaque changement est journalisé sur la fiche du client.
- Le sélecteur bloque la propagation du clic : il n'ouvre plus la fiche par
  accident.

## Vérifications

- en-têtes : `# | Nom | Téléphone | Email | Où en est-on ?` ;
- les six choix sont proposés, « — à qualifier — » compris ;
- « Devis envoyé » sur un client sans affaire → affaire créée en base
  (`Projet — Saint-Chinian = devis_envoye`), valeur relue correcte ;
- le clic sur le sélecteur n'ouvre pas la fiche ;
- après rechargement, le statut est toujours là.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_