### PR TITLE
Leads Meta : dire si Facebook a déjà joint le site

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -72,6 +72,10 @@ model Settings {
   // Jeton de vérification à recopier dans le tableau de bord Meta
   metaVerifyToken   String   @default("")
   metaLeadsEnabled  Boolean  @default(true)
+  // Dernier signal reçu de Facebook sur /api/meta/webhook. Vide = l'URL de
+  // rappel n'a jamais été déclarée dans l'application Meta : les prospects ne
+  // peuvent pas arriver tout seuls, et rien ne le disait à l'écran.
+  metaWebhookAt     DateTime?
   // Clé de la porte d'entrée « simple » : Zapier / Make y poste les prospects
   // sans passer par la validation d'application Meta.
   leadsApiKey       String   @default("")

--- a/app/src/app/admin/meta/page.tsx
+++ b/app/src/app/admin/meta/page.tsx
@@ -30,6 +30,7 @@ type Status = {
   connectedAt: string | null;
   leadsEnabled: boolean;
   verifyToken: string;
+  webhookAt: string | null;
   webhookUrl: string;
   redirectUri: string;
   leads: Lead[];
@@ -366,6 +367,22 @@ export default function AdminMetaPage() {
           </p>
           <Copiable label="URL de rappel" value={s.webhookUrl} />
           <Copiable label="Jeton de vérification" value={s.verifyToken || "— enregistrez l'étape 1"} />
+
+          {/* Sans ce repère, une étape 3 oubliée ne se voit nulle part : la page
+              affiche « connecté » et les prospects n'arrivent jamais. */}
+          {s.webhookAt ? (
+            <p className="rounded-xl bg-leaf-50 px-4 py-3 text-sm text-leaf-800">
+              ✓ Facebook a bien joint le site — dernier signal le{" "}
+              <b>{new Date(s.webhookAt).toLocaleString("fr-FR")}</b>.
+            </p>
+          ) : (
+            <p className="rounded-xl bg-amber-50 px-4 py-3 text-sm text-amber-900">
+              <b>Facebook n&apos;a encore jamais joint le site.</b> Tant que les deux valeurs
+              ci-dessus ne sont pas déclarées dans votre application (produit Webhooks, objet
+              Page, champ <b>leadgen</b>), les nouveaux prospects n&apos;arriveront pas tout
+              seuls — il faut cliquer sur « Importer les prospects existants ».
+            </p>
+          )}
         </section>
 
         {/* 4. Prospects reçus */}

--- a/app/src/app/api/admin/meta/route.ts
+++ b/app/src/app/api/admin/meta/route.ts
@@ -30,6 +30,7 @@ async function status() {
     connectedAt: s.metaConnectedAt,
     leadsEnabled: s.metaLeadsEnabled,
     verifyToken: s.metaVerifyToken,
+    webhookAt: s.metaWebhookAt,
     webhookUrl: `${site}/api/meta/webhook`,
     // Facebook refuse la connexion si cette adresse n'est pas déclarée dans
     // « Facebook Login → Valid OAuth Redirect URIs » : il faut la montrer.

--- a/app/src/app/api/meta/webhook/route.ts
+++ b/app/src/app/api/meta/webhook/route.ts
@@ -4,6 +4,11 @@ import { fetchLead, parseLead, saveLead, verifySignature } from "@/lib/meta";
 import { notifyOwnerNewLead } from "@/lib/notifications";
 import { prisma } from "@/lib/prisma";
 
+/** Trace du dernier appel de Facebook : le seul moyen de savoir si le lien existe. */
+async function noterSignal() {
+  await prisma.settings.updateMany({ data: { metaWebhookAt: new Date() } });
+}
+
 export const dynamic = "force-dynamic";
 export const maxDuration = 30;
 
@@ -16,6 +21,7 @@ export async function GET(req: NextRequest) {
     settings.metaVerifyToken &&
     p.get("hub.verify_token") === settings.metaVerifyToken
   ) {
+    await noterSignal();
     return new NextResponse(p.get("hub.challenge") ?? "", {
       status: 200,
       headers: { "Content-Type": "text/plain" },
@@ -32,6 +38,7 @@ export async function POST(req: NextRequest) {
   if (!verifySignature(raw, req.headers.get("x-hub-signature-256"), settings.metaAppSecret)) {
     return NextResponse.json({ error: "Signature invalide" }, { status: 401 });
   }
+  await noterSignal();
   if (!settings.metaLeadsEnabled) return NextResponse.json({ ok: true });
 
   let body: {


### PR DESCRIPTION
Le client demande pourquoi les prospects du jour n'arrivent pas. Diagnostic :
connecter le compte abonne la **Page** à l'application (`subscribed_apps`), mais
l'**URL de rappel** doit encore être déclarée dans le produit *Webhooks* de
l'application Meta. Sans elle, Facebook n'a aucune adresse où envoyer
l'événement — l'écran affiche « connecté » et aucun prospect n'arrive jamais.
Rien ne distinguait les deux situations.

## Ce qui change

- `Settings.metaWebhookAt` est horodaté à **chaque appel de Facebook** sur
  `/api/meta/webhook`, poignée de main de vérification comprise.
- L'étape 3 affiche désormais l'un des deux :
  - ✓ « Facebook a bien joint le site — dernier signal le … » ;
  - ⚠️ « Facebook n'a encore jamais joint le site », avec l'étape manquante
    nommée (produit Webhooks, objet Page, champ `leadgen`) et le rappel que
    « Importer les prospects existants » reste disponible en attendant.

## Vérifications

- avant toute vérification Facebook : `webhookAt` vide → bandeau ambre ;
- appel de vérification avec le bon jeton → renvoie bien le `hub.challenge`
  (`12345`), et `webhookAt` est horodaté ;
- mauvais jeton → 403, et rien n'est enregistré.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_