### PR TITLE
Leads à traiter : les plus récents en premier

### DIFF
--- a/app/src/app/admin/page.tsx
+++ b/app/src/app/admin/page.tsx
@@ -343,8 +343,8 @@ export default function AdminDashboard() {
             </Link>
           </div>
           <p className="text-sm text-leaf-800/60">
-            Sans rendez-vous ni devis. Les lignes vertes sont faites, elles
-            disparaissent au bout de 24 h.
+            Les plus récents d'abord, sans rendez-vous ni devis. Les lignes
+            vertes sont faites, elles disparaissent au bout de 24 h.
           </p>
 
           {aTraiter.length === 0 ? (

--- a/app/src/app/api/admin/dashboard/route.ts
+++ b/app/src/app/api/admin/dashboard/route.ts
@@ -64,7 +64,12 @@ export async function GET() {
           affaires: { none: {} },
           bookings: { none: {} },
         },
-        orderBy: { createdAt: "asc" },
+        // Les plus récents d'abord. En triant du plus ancien au plus récent,
+        // les 92 leads importés occupaient les douze places et un prospect
+        // arrivé le matin même se retrouvait en position 90, invisible — alors
+        // que c'est lui qu'il faut rappeler tout de suite. L'ancienneté en
+        // rouge reste là pour signaler ceux qui traînent.
+        orderBy: { createdAt: "desc" },
         take: 12,
         select: {
           id: true,


### PR DESCRIPTION
Le client signale que les prospects Meta arrivés aujourd'hui n'apparaissent pas
dans « Leads à traiter ». Ils y sont pourtant : le compteur de clients est passé
de 101 à 105.

La liste était triée **du plus ancien au plus récent**, un choix raisonnable
avec cinq leads. Avec les 92 importés, ces 92 occupent les douze places
affichées et un prospect entré le matin même se retrouve en position 90 —
invisible, alors que c'est précisément celui qu'il faut rappeler dans l'heure.

Le tri passe donc en **plus récents d'abord**. L'ancienneté en rouge (« 26 jours »)
reste là pour signaler ceux qui traînent, et « Voir tout » mène à la liste
complète des clients pour les traiter au fond.

## Vérification

Jeu de test : 90 leads datés d'hier + 3 arrivés il y a 5, 40 et 120 minutes.

```
total en attente : 93
les 6 premiers affichés :
  - Nouveau-A Aujourdhui    0 j
  - Nouveau-B Aujourdhui    0 j
  - Nouveau-C Aujourdhui    0 j
  - Ancien0 Import          1 j
  - Ancien1 Import          1 j
  - Ancien2 Import          1 j
```

Avant ce correctif, les trois « Nouveau » n'apparaissaient nulle part.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_