### PR TITLE
Fiche client : corriger une ligne de l'historique des échanges

### DIFF
--- a/app/src/app/admin/clients/FicheContact.tsx
+++ b/app/src/app/admin/clients/FicheContact.tsx
@@ -70,6 +70,12 @@ export default function FicheContact({
   const [message, setMessage] = useState("");
   const [type, setType] = useState("appel");
   const [enregistre, setEnregistre] = useState(false);
+  // Ligne du journal en cours de correction (une seule à la fois). Déclaré ici,
+  // avec les autres : un hook placé après le « return » de chargement change le
+  // nombre de hooks entre deux rendus et React refuse de rendre la fiche.
+  const [editId, setEditId] = useState("");
+  const [editTexte, setEditTexte] = useState("");
+  const [editType, setEditType] = useState("note");
 
   useEffect(() => {
     fetch(`/api/admin/contacts/${id}`)
@@ -90,6 +96,22 @@ export default function FicheContact({
     setEnregistre(true);
     setTimeout(() => setEnregistre(false), 1500);
     onChange();
+  }
+
+  async function enregistrerEchange(echangeId: string) {
+    const contenu = editTexte.trim();
+    if (!contenu) return;
+    const res = await fetch(`/api/admin/contacts/${id}/echanges/${echangeId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contenu, type: editType }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setD((c) => (c ? { ...c, interactions: data.interactions } : c));
+      setEditId("");
+      onChange();
+    }
   }
 
   async function ajouterEchange() {
@@ -243,8 +265,57 @@ export default function FicheContact({
                   {TYPES_INTERACTION[i.type] ?? i.type} · {quand(i.createdAt)}
                   {i.auteur ? ` · ${i.auteur}` : ""}
                 </span>
-                <br />
-                <span className="text-leaf-800/90">{i.contenu}</span>
+                {editId === i.id ? (
+                  <div className="mt-1 flex flex-col gap-2 sm:flex-row">
+                    <select
+                      className="input !w-auto !py-1.5"
+                      value={editType}
+                      onChange={(e) => setEditType(e.target.value)}
+                    >
+                      {["appel", "email", "sms", "note"].map((t) => (
+                        <option key={t} value={t}>
+                          {TYPES_INTERACTION[t]}
+                        </option>
+                      ))}
+                    </select>
+                    <input
+                      className="input flex-1 !py-1.5"
+                      value={editTexte}
+                      autoFocus
+                      onChange={(e) => setEditTexte(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") enregistrerEchange(i.id);
+                        if (e.key === "Escape") setEditId("");
+                      }}
+                    />
+                    <button
+                      className="btn-primary !px-3 !py-1.5 text-sm"
+                      onClick={() => enregistrerEchange(i.id)}
+                    >
+                      Enregistrer
+                    </button>
+                    <button
+                      className="btn-secondary !px-3 !py-1.5 text-sm"
+                      onClick={() => setEditId("")}
+                    >
+                      Annuler
+                    </button>
+                  </div>
+                ) : (
+                  <div className="flex items-start justify-between gap-2">
+                    <span className="text-leaf-800/90">{i.contenu}</span>
+                    <button
+                      onClick={() => {
+                        setEditId(i.id);
+                        setEditTexte(i.contenu);
+                        setEditType(["appel", "email", "sms", "note"].includes(i.type) ? i.type : "note");
+                      }}
+                      className="shrink-0 text-xs font-semibold text-leaf-700 underline"
+                    >
+                      Modifier
+                    </button>
+                  </div>
+                )}
               </li>
             ))}
           </ul>

--- a/app/src/app/api/admin/contacts/[id]/echanges/[echangeId]/route.ts
+++ b/app/src/app/api/admin/contacts/[id]/echanges/[echangeId]/route.ts
@@ -1,0 +1,61 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { isAdminAuthenticated } from "@/lib/auth";
+
+export const dynamic = "force-dynamic";
+
+const TYPES = ["appel", "email", "sms", "note", "rdv", "devis"];
+
+/** Le journal du contact, tel que la fiche l'affiche. */
+async function journal(contactId: string) {
+  return prisma.interaction.findMany({
+    where: { contactId },
+    orderBy: { createdAt: "desc" },
+    take: 100,
+  });
+}
+
+/**
+ * PATCH /api/admin/contacts/:id/echanges/:echangeId — corriger une ligne du
+ * journal. Une note prise à la volée pendant un appel contient souvent une
+ * faute ou une information incomplète ; jusqu'ici elle était figée.
+ *
+ * La date et l'auteur ne bougent pas : c'est l'historique, pas un brouillon.
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string; echangeId: string } }
+) {
+  if (!isAdminAuthenticated()) {
+    return NextResponse.json({ error: "Non autorisé" }, { status: 401 });
+  }
+  let body: Record<string, unknown>;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "JSON invalide" }, { status: 400 });
+  }
+
+  // L'échange doit bien appartenir à ce contact : sans cette vérification, un
+  // identifiant d'échange suffirait à modifier la fiche de n'importe qui.
+  const echange = await prisma.interaction.findUnique({ where: { id: params.echangeId } });
+  if (!echange || echange.contactId !== params.id) {
+    return NextResponse.json({ error: "introuvable" }, { status: 404 });
+  }
+
+  const data: Record<string, unknown> = {};
+  if (typeof body.contenu === "string") {
+    const contenu = body.contenu.trim();
+    if (!contenu) return NextResponse.json({ error: "Le contenu est vide." }, { status: 400 });
+    data.contenu = contenu.slice(0, 2000);
+  }
+  if (typeof body.type === "string" && TYPES.includes(body.type)) {
+    data.type = body.type;
+  }
+  if (!Object.keys(data).length) {
+    return NextResponse.json({ error: "Rien à modifier." }, { status: 400 });
+  }
+
+  await prisma.interaction.update({ where: { id: params.echangeId }, data });
+  return NextResponse.json({ ok: true, interactions: await journal(params.id) });
+}


### PR DESCRIPTION
Une note prise à la volée pendant un appel était figée dès l'enregistrement,
fautes comprises. Chaque ligne porte désormais un lien **« Modifier »**.

## Ce qui change

- `PATCH /api/admin/contacts/:id/echanges/:echangeId` corrige le texte et le
  type. La route **vérifie que l'échange appartient bien à ce contact** : sans
  cela, un identifiant d'échange suffirait à modifier la fiche de n'importe qui.
- **La date et l'auteur ne bougent pas** — c'est un historique, pas un
  brouillon. Seuls le contenu et le type sont modifiables.
- Correction sur place : le texte devient un champ, **Entrée** enregistre,
  **Échap** annule.

## Un défaut corrigé en cours de route

J'avais d'abord déclaré les états de l'édition **après** le `return` de
chargement de la fiche. Le nombre de hooks changeait donc entre deux rendus et
React refusait d'afficher la fiche entière (erreur #310) — repéré au test, les
états sont remontés avec les autres.

## Vérifications

- ajout d'un échange fautif (« Rapelé, pas de réponce ») ;
- clic sur « Modifier » → champ pré-rempli avec le texte existant ;
- correction du texte et passage du type en « Appel » → la ligne affiche
  « APPEL · 21 AOÛT 26, 13:38 · GERANT — Rappelé, pas de réponse — rappeler
  jeudi », **même date, même auteur** ;
- après rechargement de la page : la correction est toujours là.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_