### PR TITLE
Clients : onglets de filtrage sous la recherche

### DIFF
--- a/app/src/app/admin/clients/page.tsx
+++ b/app/src/app/admin/clients/page.tsx
@@ -100,6 +100,21 @@ const ICONES = {
   ),
 };
 
+/**
+ * Onglets du tableau. Les secteurs se lisent dans le code postal du client
+ * (34 = Hérault, 33 = Gironde) : ça fonctionne sans avoir à créer d'agences,
+ * et le filtre « Tous secteurs » reste disponible pour qui en a configuré.
+ */
+const ONGLETS: { id: string; label: string; statut?: string; cp?: string }[] = [
+  { id: "tous", label: "Tous" },
+  { id: "attente", label: "En attente de devis", statut: "devis_a_faire" },
+  { id: "envoye", label: "Devis envoyé", statut: "devis_envoye" },
+  { id: "en_cours", label: "Chantiers en cours", statut: "chantier_en_cours" },
+  { id: "termines", label: "Chantiers terminés", statut: "termine" },
+  { id: "beziers", label: "Béziers et alentours", cp: "34" },
+  { id: "bordeaux", label: "Bordeaux et alentours", cp: "33" },
+];
+
 export default function AdminClientsPage() {
   const [contacts, setContacts] = useState<Contact[]>([]);
   const [stats, setStats] = useState<Stats>({ total: 0, actifs: 0, perdus: 0, caTotal: 0 });
@@ -108,6 +123,7 @@ export default function AdminClientsPage() {
   const [chargement, setChargement] = useState(true);
   const [q, setQ] = useState("");
   const [agence, setAgence] = useState("");
+  const [onglet, setOnglet] = useState("tous");
   const [ouvert, setOuvert] = useState<string | null>(null);
   const [nouveau, setNouveau] = useState(false);
   const [majStatut, setMajStatut] = useState("");
@@ -126,6 +142,9 @@ export default function AdminClientsPage() {
     const p = new URLSearchParams();
     if (q.trim()) p.set("q", q.trim());
     if (agence) p.set("agence", agence);
+    const o = ONGLETS.find((x) => x.id === onglet);
+    if (o?.statut) p.set("statut", o.statut);
+    if (o?.cp) p.set("cp", o.cp);
     fetch(`/api/admin/contacts?${p.toString()}`)
       .then((r) => {
         if (r.status === 401) {
@@ -160,7 +179,7 @@ export default function AdminClientsPage() {
     const t = setTimeout(charger, 300);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [q, agence]);
+  }, [q, agence, onglet]);
 
   /**
    * Suivi commercial depuis la liste. La vérité vit dans l'affaire du client :
@@ -239,6 +258,23 @@ export default function AdminClientsPage() {
         </button>
       </div>
 
+      {/* Onglets : les tris du quotidien, à un clic. */}
+      <div className="mb-4 flex flex-wrap gap-1.5">
+        {ONGLETS.map((o) => (
+          <button
+            key={o.id}
+            onClick={() => setOnglet(o.id)}
+            className={`rounded-full px-3 py-1.5 text-sm font-semibold transition ${
+              onglet === o.id
+                ? "bg-leaf-600 text-white"
+                : "bg-white text-leaf-800/70 ring-1 ring-inset ring-leaf-200 hover:bg-leaf-50"
+            }`}
+          >
+            {o.label}
+          </button>
+        ))}
+      </div>
+
       {nouveau && (
         <div className="card mb-4 space-y-2 border-2 border-leaf-300">
           <p className="font-semibold">Nouveau client</p>
@@ -300,7 +336,7 @@ export default function AdminClientsPage() {
 
       {!chargement && contacts.length === 0 && (
         <div className="card py-8 text-center text-sm text-leaf-800/60">
-          {q || agence ? (
+          {q || agence || onglet !== "tous" ? (
             "Aucun client ne correspond."
           ) : (
             <>

--- a/app/src/app/api/admin/contacts/route.ts
+++ b/app/src/app/api/admin/contacts/route.ts
@@ -9,7 +9,8 @@ export const dynamic = "force-dynamic";
 const MAX_RESULTATS = 200;
 
 /**
- * GET /api/admin/contacts?q=&origine=&agence= — la base « Tous les clients ».
+ * GET /api/admin/contacts?q=&origine=&agence=&statut=&cp= — la base
+ * « Tous les clients ».
  * Recherche serveur sur nom, téléphone, email, ville et code postal.
  *
  * Chaque ligne est enrichie de ce que le gérant veut voir d'un coup d'œil :
@@ -25,6 +26,11 @@ export async function GET(req: NextRequest) {
   const q = (p.get("q") ?? "").trim();
   const origine = (p.get("origine") ?? "").trim();
   const agenceId = (p.get("agence") ?? "").trim();
+  // Onglets du tableau : une étape du pipeline, ou un secteur par préfixe de
+  // code postal. Le préfixe plutôt que l'agence, parce qu'un secteur se lit
+  // dans le code postal du client même quand aucune agence n'est configurée.
+  const statut = (p.get("statut") ?? "").trim();
+  const cp = (p.get("cp") ?? "").trim();
 
   const contient = { contains: q, mode: "insensitive" as const };
   const where = {
@@ -45,6 +51,8 @@ export async function GET(req: NextRequest) {
         : {},
       origine ? { origine } : {},
       agenceId ? { agenceId } : {},
+      statut ? { affaires: { some: { statut } } } : {},
+      cp ? { postalCode: { startsWith: cp } } : {},
     ],
   };
 


### PR DESCRIPTION
Sept onglets sous la barre de recherche du tableau des clients :

**Tous** · **En attente de devis** · **Devis envoyé** · **Chantiers en cours** ·
**Chantiers terminés** · **Béziers et alentours** · **Bordeaux et alentours**

## Choix de conception

Les quatre onglets d'étape s'appuient sur le `statut` de l'affaire du client —
la même source que la colonne « Où en est-on ? » et que la page Affaires.

Les deux onglets de secteur filtrent sur le **préfixe du code postal**
(34 = Hérault, 33 = Gironde) plutôt que sur la relation `agenceId`. Le compte du
client ne comporte aucune agence configurée — le sélecteur « Tous secteurs » est
d'ailleurs absent de son écran — et un filtre par agence n'aurait donc rien
renvoyé. Le secteur se lit directement dans le code postal du client. Le
sélecteur d'agences reste en place pour les comptes qui en configurent.

`GET /api/admin/contacts` accepte deux paramètres de plus, `statut` et `cp`,
qui se combinent avec la recherche et le filtre d'agence.

## Vérifications

Jeu de test : 3 clients en 34, 3 en 33, 1 en 75, à des étapes différentes.

```
Tous                     → 7
En attente de devis      → 1 : Anne Beziers1
Devis envoyé             → 2 : Bruno Beziers2, David Bordeaux1
Chantiers en cours       → 1 : Carine Beziers3
Chantiers terminés       → 1 : Elise Bordeaux2
Béziers et alentours     → 3 (les trois en 34)
Bordeaux et alentours    → 3 (les trois en 33)
Béziers + recherche « Bruno » → 1
```

Le client parisien n'apparaît que dans « Tous », et onglet + recherche se
combinent bien.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_