### PR TITLE
Clients : les onglets de secteur passent à un vrai rayon de 40 km

### DIFF
--- a/app/src/app/admin/clients/page.tsx
+++ b/app/src/app/admin/clients/page.tsx
@@ -100,19 +100,22 @@ const ICONES = {
   ),
 };
 
+const RAYON_SECTEUR = 40;
+
 /**
- * Onglets du tableau. Les secteurs se lisent dans le code postal du client
- * (34 = Hérault, 33 = Gironde) : ça fonctionne sans avoir à créer d'agences,
- * et le filtre « Tous secteurs » reste disponible pour qui en a configuré.
+ * Onglets du tableau. Un secteur est un vrai cercle de 40 km autour de la
+ * ville, calculé à partir du code postal du client — pas un département :
+ * Narbonne est à 28 km de Béziers mais dans l'Aude, Montpellier est dans
+ * l'Hérault mais à 59 km.
  */
-const ONGLETS: { id: string; label: string; statut?: string; cp?: string }[] = [
+const ONGLETS: { id: string; label: string; statut?: string; centre?: string }[] = [
   { id: "tous", label: "Tous" },
   { id: "attente", label: "En attente de devis", statut: "devis_a_faire" },
   { id: "envoye", label: "Devis envoyé", statut: "devis_envoye" },
   { id: "en_cours", label: "Chantiers en cours", statut: "chantier_en_cours" },
   { id: "termines", label: "Chantiers terminés", statut: "termine" },
-  { id: "beziers", label: "Béziers et alentours", cp: "34" },
-  { id: "bordeaux", label: "Bordeaux et alentours", cp: "33" },
+  { id: "beziers", label: "Béziers et alentours", centre: "34500" },
+  { id: "bordeaux", label: "Bordeaux et alentours", centre: "33000" },
 ];
 
 export default function AdminClientsPage() {
@@ -144,7 +147,10 @@ export default function AdminClientsPage() {
     if (agence) p.set("agence", agence);
     const o = ONGLETS.find((x) => x.id === onglet);
     if (o?.statut) p.set("statut", o.statut);
-    if (o?.cp) p.set("cp", o.cp);
+    if (o?.centre) {
+      p.set("centre", o.centre);
+      p.set("rayon", String(RAYON_SECTEUR));
+    }
     fetch(`/api/admin/contacts?${p.toString()}`)
       .then((r) => {
         if (r.status === 401) {

--- a/app/src/app/api/admin/contacts/route.ts
+++ b/app/src/app/api/admin/contacts/route.ts
@@ -3,13 +3,14 @@ import { prisma } from "@/lib/prisma";
 import { isAdminAuthenticated } from "@/lib/auth";
 import { creerOuCompleterContact, journaliser, phoneKeyOf } from "@/lib/contacts";
 import { estGagnee, estPerdue } from "@/lib/pipeline";
+import { cpAutour } from "@/lib/geo";
 
 export const dynamic = "force-dynamic";
 
 const MAX_RESULTATS = 200;
 
 /**
- * GET /api/admin/contacts?q=&origine=&agence=&statut=&cp= — la base
+ * GET /api/admin/contacts?q=&origine=&agence=&statut=&centre=&rayon= — la base
  * « Tous les clients ».
  * Recherche serveur sur nom, téléphone, email, ville et code postal.
  *
@@ -26,11 +27,13 @@ export async function GET(req: NextRequest) {
   const q = (p.get("q") ?? "").trim();
   const origine = (p.get("origine") ?? "").trim();
   const agenceId = (p.get("agence") ?? "").trim();
-  // Onglets du tableau : une étape du pipeline, ou un secteur par préfixe de
-  // code postal. Le préfixe plutôt que l'agence, parce qu'un secteur se lit
-  // dans le code postal du client même quand aucune agence n'est configurée.
+  // Onglets du tableau : une étape du pipeline, ou un secteur géographique.
+  // Le secteur est un vrai cercle autour d'une ville, pas un département :
+  // Béziers à 40 km déborde sur l'Aude et s'arrête avant Montpellier.
   const statut = (p.get("statut") ?? "").trim();
-  const cp = (p.get("cp") ?? "").trim();
+  const centre = (p.get("centre") ?? "").trim();
+  const rayon = Math.min(300, Math.max(1, Number(p.get("rayon")) || 40));
+  const codesDuSecteur = centre ? cpAutour(centre, rayon) : [];
 
   const contient = { contains: q, mode: "insensitive" as const };
   const where = {
@@ -52,7 +55,7 @@ export async function GET(req: NextRequest) {
       origine ? { origine } : {},
       agenceId ? { agenceId } : {},
       statut ? { affaires: { some: { statut } } } : {},
-      cp ? { postalCode: { startsWith: cp } } : {},
+      centre ? { postalCode: { in: codesDuSecteur } } : {},
     ],
   };
 

--- a/app/src/lib/geo.ts
+++ b/app/src/lib/geo.ts
@@ -24,3 +24,22 @@ export function distanceKm(
     Math.cos((a.lat * Math.PI) / 180) * Math.cos((b.lat * Math.PI) / 180) * Math.sin(dLng / 2) ** 2;
   return 2 * R * Math.asin(Math.sqrt(s));
 }
+
+/**
+ * Les codes postaux situés dans un rayon donné autour d'un autre. Sert aux
+ * onglets par secteur : « Béziers et alentours » n'est pas le département 34,
+ * c'est bien un cercle de 40 km — qui déborde sur l'Aude et s'arrête avant
+ * Montpellier.
+ *
+ * La table est parcourue en entier (6 188 entrées) : c'est instantané, et ça
+ * évite d'entretenir une liste de codes postaux à la main.
+ */
+export function cpAutour(centre: string, rayonKm: number): string[] {
+  const depart = cpToLatLng(centre);
+  if (!depart) return [];
+  const dedans: string[] = [];
+  for (const [cp, [lat, lng]] of Object.entries(CP_GPS)) {
+    if (distanceKm(depart, { lat, lng }) <= rayonKm) dedans.push(cp);
+  }
+  return dedans;
+}


### PR DESCRIPTION
Le préfixe de département était une approximation grossière de « et alentours » :
il faisait entrer Montpellier (à 59 km, mais dans l'Hérault) et laissait dehors
Narbonne (à 28 km, mais dans l'Aude).

Les deux onglets calculent désormais un **vrai cercle de 40 km** autour de
Béziers (34500) et de Bordeaux (33000).

## Comment

`cpAutour(centre, rayonKm)` dans `lib/geo.ts` parcourt la table embarquée des
6 188 codes postaux français et renvoie ceux qui tombent dans le rayon
(haversine). Les onglets envoient `centre` et `rayon`, la requête filtre sur cet
ensemble. Aucun service externe, comme partout ailleurs dans l'application.

Couverture obtenue : **46 codes postaux** autour de Béziers (départements 11
et 34), **61** autour de Bordeaux (33).

## Vérifications

Huit clients placés exprès autour et loin des deux villes :

| Client | Distance | Béziers | Bordeaux |
|---|---|---|---|
| Béziers 34500 | 0 km | ✅ | — |
| Saint-Chinian 34360 | 30 km | ✅ | — |
| **Narbonne 11100** | 28 km | ✅ *(autre département)* | — |
| **Montpellier 34000** | 59 km | ❌ *(même département)* | — |
| Bordeaux 33000 | 0 km | — | ✅ |
| Libourne 33500 | 28 km | — | ✅ |
| Dax 40100 | 134 km | — | ❌ |
| Paris 75011 | — | ❌ | ❌ |

Les deux lignes en gras sont exactement celles que l'ancien filtre traitait à
l'envers. Vérifié par l'API et dans le navigateur.

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_