### PR TITLE
Secteurs : reconnaître la ville, et dire qui ne peut pas être classé

### DIFF
--- a/app/prisma/schema.prisma
+++ b/app/prisma/schema.prisma
@@ -399,6 +399,10 @@ model Lead {
   phone      String
   email      String   @default("")
   postalCode String
+  // Ville et adresse quand le formulaire les demande : sans elles, un prospect
+  // ne peut être rattaché à aucun secteur.
+  city       String   @default("")
+  address    String   @default("")
   message    String   @default("")
   source     String   @default("site") // site | meta
   // Identifiant du lead chez Meta : sert à écarter les doublons (webhook + import).

--- a/app/src/app/admin/clients/page.tsx
+++ b/app/src/app/admin/clients/page.tsx
@@ -108,14 +108,14 @@ const RAYON_SECTEUR = 40;
  * Narbonne est à 28 km de Béziers mais dans l'Aude, Montpellier est dans
  * l'Hérault mais à 59 km.
  */
-const ONGLETS: { id: string; label: string; statut?: string; centre?: string }[] = [
+const ONGLETS: { id: string; label: string; statut?: string; centre?: string; ville?: string }[] = [
   { id: "tous", label: "Tous" },
   { id: "attente", label: "En attente de devis", statut: "devis_a_faire" },
   { id: "envoye", label: "Devis envoyé", statut: "devis_envoye" },
   { id: "en_cours", label: "Chantiers en cours", statut: "chantier_en_cours" },
   { id: "termines", label: "Chantiers terminés", statut: "termine" },
-  { id: "beziers", label: "Béziers et alentours", centre: "34500" },
-  { id: "bordeaux", label: "Bordeaux et alentours", centre: "33000" },
+  { id: "beziers", label: "Béziers et alentours", centre: "34500", ville: "Béziers" },
+  { id: "bordeaux", label: "Bordeaux et alentours", centre: "33000", ville: "Bordeaux" },
 ];
 
 export default function AdminClientsPage() {
@@ -130,6 +130,7 @@ export default function AdminClientsPage() {
   const [ouvert, setOuvert] = useState<string | null>(null);
   const [nouveau, setNouveau] = useState(false);
   const [majStatut, setMajStatut] = useState("");
+  const [sansLieu, setSansLieu] = useState(0);
   const [brouillon, setBrouillon] = useState({
     firstName: "",
     lastName: "",
@@ -150,6 +151,7 @@ export default function AdminClientsPage() {
     if (o?.centre) {
       p.set("centre", o.centre);
       p.set("rayon", String(RAYON_SECTEUR));
+      if (o.ville) p.set("ville", o.ville);
     }
     fetch(`/api/admin/contacts?${p.toString()}`)
       .then((r) => {
@@ -163,6 +165,7 @@ export default function AdminClientsPage() {
         setContacts(d.contacts ?? []);
         setStats(d.stats ?? { total: 0, actifs: 0, perdus: 0, caTotal: 0 });
         setTronque(Boolean(d.tronque));
+        setSansLieu(d.sansLieu ?? 0);
       })
       .catch(() => {})
       .finally(() => setChargement(false));
@@ -280,6 +283,17 @@ export default function AdminClientsPage() {
           </button>
         ))}
       </div>
+
+      {/* Un secteur ne peut classer que ce qu'il sait situer. Le dire ici évite
+          de chercher longtemps pourquoi un client connu n'apparaît pas. */}
+      {ONGLETS.find((o) => o.id === onglet)?.centre && sansLieu > 0 && (
+        <p className="mb-4 rounded-xl bg-amber-50 px-3 py-2 text-sm text-amber-900">
+          <b>{sansLieu} client(s) sans ville ni code postal</b> n&apos;apparaissent dans aucun
+          secteur — vos formulaires publicitaires ne demandent pas l&apos;adresse. Ouvrez leur
+          fiche pour la renseigner, ou ajoutez la question « code postal » à votre formulaire
+          Meta pour les prochains.
+        </p>
+      )}
 
       {nouveau && (
         <div className="card mb-4 space-y-2 border-2 border-leaf-300">

--- a/app/src/app/api/admin/contacts/route.ts
+++ b/app/src/app/api/admin/contacts/route.ts
@@ -34,6 +34,14 @@ export async function GET(req: NextRequest) {
   const centre = (p.get("centre") ?? "").trim();
   const rayon = Math.min(300, Math.max(1, Number(p.get("rayon")) || 40));
   const codesDuSecteur = centre ? cpAutour(centre, rayon) : [];
+  const villeCentre = (p.get("ville") ?? "").trim();
+  // « Béziers » et « beziers » désignent la même ville : on cherche les deux
+  // formes, PostgreSQL ignorant la casse mais pas les accents.
+  const villesCherchees = villeCentre
+    ? Array.from(
+        new Set([villeCentre, villeCentre.normalize("NFD").replace(/[\u0300-\u036f]/g, "")])
+      )
+    : [];
 
   const contient = { contains: q, mode: "insensitive" as const };
   const where = {
@@ -55,7 +63,18 @@ export async function GET(req: NextRequest) {
       origine ? { origine } : {},
       agenceId ? { agenceId } : {},
       statut ? { affaires: { some: { statut } } } : {},
-      centre ? { postalCode: { in: codesDuSecteur } } : {},
+      // Le code postal d'abord, la ville en secours : un prospect publicitaire
+      // qui n'a laissé que « Béziers » doit quand même sortir dans son secteur.
+      centre
+        ? {
+            OR: [
+              { postalCode: { in: codesDuSecteur } },
+              ...villesCherchees.map((v) => ({
+                city: { contains: v, mode: "insensitive" as const },
+              })),
+            ],
+          }
+        : {},
     ],
   };
 
@@ -147,7 +166,14 @@ export async function GET(req: NextRequest) {
   const nbPerdus = Array.from(resumes.values()).filter((r) => r.perdu).length;
   const caTotal = Array.from(resumes.values()).reduce((acc, r) => acc + r.ca, 0);
 
+  // Un client sans code postal ni ville n'appartient à aucun secteur : le dire
+  // évite de croire que le filtre perd des gens.
+  const sansLieu = await prisma.contact.count({
+    where: { postalCode: "", city: "" },
+  });
+
   return NextResponse.json({
+    sansLieu,
     contacts: contacts.map(({ _count, ...c }) => {
       const r = resumes.get(c.id);
       return {

--- a/app/src/lib/meta.ts
+++ b/app/src/lib/meta.ts
@@ -153,7 +153,11 @@ const FIELD_ALIASES: Record<string, string[]> = {
   name: ["full_name", "nom_complet", "name", "nom", "prenom", "prénom"],
   phone: ["phone_number", "telephone", "téléphone", "tel", "numero", "numéro", "phone"],
   email: ["email", "e_mail", "courriel", "mail"],
-  postalCode: ["post_code", "postal_code", "zip_code", "code_postal", "cp", "postcode"],
+  postalCode: ["post_code", "postal_code", "zip_code", "code_postal", "cp", "postcode", "zip"],
+  // La ville n'était pas lue : un formulaire qui la demande voyait sa réponse
+  // jetée, et le client se retrouvait sans localisation donc sans secteur.
+  city: ["city", "ville", "commune", "localite", "localité", "town"],
+  address: ["street_address", "adresse", "address", "rue"],
   message: ["message", "projet", "besoin", "commentaire", "precisions", "précisions"],
 };
 
@@ -180,6 +184,8 @@ export function parseLead(lead: MetaLead, formName = "") {
     phone: pick(fields, FIELD_ALIASES.phone),
     email: pick(fields, FIELD_ALIASES.email),
     postalCode: pick(fields, FIELD_ALIASES.postalCode),
+    city: pick(fields, FIELD_ALIASES.city),
+    address: pick(fields, FIELD_ALIASES.address),
     message: pick(fields, FIELD_ALIASES.message),
     formName,
     adName: lead.ad_name ?? "",
@@ -189,22 +195,33 @@ export function parseLead(lead: MetaLead, formName = "") {
   };
 }
 
-/** Enregistre un prospect Meta, sans jamais créer de doublon. */
+/**
+ * Enregistre un prospect Meta, sans jamais créer de doublon.
+ *
+ * Un prospect déjà connu ne crée rien, mais sa fiche client est tout de même
+ * complétée : les premiers imports ne lisaient ni la ville ni l'adresse, et
+ * `creerOuCompleterContact` ne remplace jamais une valeur remplie par du vide.
+ * Relancer l'import récupère donc ce qui avait été laissé de côté.
+ */
 export async function saveLead(parsed: ReturnType<typeof parseLead>): Promise<boolean> {
   const existing = await prisma.lead.findFirst({ where: { externalId: parsed.externalId } });
-  if (existing) return false;
   const { createdAt, ...rest } = parsed;
-  await prisma.lead.create({
-    data: { ...rest, source: "meta", ...(createdAt ? { createdAt } : {}) },
-  });
+  if (!existing) {
+    await prisma.lead.create({
+      data: { ...rest, source: "meta", ...(createdAt ? { createdAt } : {}) },
+    });
+  }
   // Les prospects publicitaires entrent aussi dans la base globale.
   const contact = await creerOuCompleterContact({
     ...splitNom(rest.name),
     phone: rest.phone,
     email: rest.email,
+    address: rest.address,
     postalCode: rest.postalCode,
+    city: rest.city,
     origine: "meta",
   });
+  if (existing) return false;
   await journaliser(
     contact.id,
     "note",


### PR DESCRIPTION
Le client signale qu'une cliente qu'il sait proche de Béziers n'apparaît pas dans
le secteur. Le rayon n'est pas en cause : **elle n'a pas de code postal**.

La cause remonte à l'import : `parseLead` ne lisait **ni la ville ni l'adresse**.
Un formulaire publicitaire qui pose la question voyait la réponse jetée, et le
contact arrivait sans localisation — donc hors de tout secteur, sans rien à
l'écran pour l'expliquer.

## Trois correctifs

**1. Ce qui est reçu est enfin conservé.** `parseLead` reconnaît `city` /
`ville` / `commune` / `localite` / `town` et `street_address` / `adresse` /
`rue`. Le modèle `Lead` gagne les colonnes `city` et `address`.

**2. Relancer l'import complète l'existant.** `saveLead` ne s'arrêtait pas à un
prospect déjà connu par hasard : il ne faisait rien du tout. Il complète
désormais la fiche client même pour un prospect déjà enregistré —
`creerOuCompleterContact` ne remplace jamais une valeur remplie par du vide. Un
clic sur « Importer les prospects existants » récupère donc ce que les versions
précédentes laissaient tomber.

**3. Le secteur accepte la ville à défaut du code postal**, cherchée **avec et
sans accent** : PostgreSQL ignore la casse mais pas les diacritiques, et
« beziers » saisi sans accent est le cas courant.

**4.** Un bandeau ambre sur les onglets de secteur compte les contacts **sans
ville ni code postal** et dit quoi faire : renseigner la fiche, ou ajouter la
question du code postal au formulaire Meta.

## Vérifications

Dix contacts localisés de façons différentes :

| Contact | Béziers | Bordeaux |
|---|---|---|
| CP 34500 | ✅ | — |
| CP 11100 (Narbonne, 28 km) | ✅ | — |
| Ville « Béziers », sans CP | ✅ | — |
| Ville « beziers », sans accent | ✅ | — |
| CP 33000 | — | ✅ |
| Ville « Bordeaux », sans CP | — | ✅ |
| CP 34000 (Montpellier, 59 km) | ❌ | ❌ |
| 3 contacts sans rien | ❌ | ❌ |

Et le bandeau annonce bien « 3 client(s) sans ville ni code postal ».

`npm run build` et `tsc --noEmit` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSuzKKTeMrnirjSwduNwdt)_